### PR TITLE
allow writing files between formats

### DIFF
--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -24,7 +24,7 @@ using DimensionalData: Forward, Reverse, formatdims, slicedims, basetypeof,
       dims2indices, indexorder, arrayorder, relationorder, StandardIndices, isrev
 
 import DimensionalData: val, data, dims, refdims, metadata, rebuild, rebuildsliced,
-                        name, label, units, bounds, sel2indices, mode, 
+                        name, label, units, bounds, sel2indices, mode,
                         order, locus, span, sampling, forwardorder
 
 export Metadata, ArrayMetadata, DimMetadata
@@ -35,7 +35,7 @@ export AbstractGeoStack, GeoStack
 
 export AbstractGeoSeries, GeoSeries
 
-export Projected
+export Projected, Converted, LatLon
 
 export missingval, boolmask, missingmask, replace_missing, aggregate, aggregate!, crs, usercrs
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -65,6 +65,8 @@ units(A::AbstractGeoArray) = getmeta(A, :units, nothing)
 rebuild(A::AbstractGeoArray, data, dims::Tuple, refdims, name, metadata, missingval=missingval(A)) =
     GeoArray(data, dims, refdims, name, metadata, missingval)
 
+Base.parent(A::AbstractGeoArray) = data(A)
+
 """
 Abstract supertype for all memory-backed GeoArrays where the data is an array.
 """

--- a/src/methods.jl
+++ b/src/methods.jl
@@ -4,7 +4,9 @@
 Replace missing values in the array with a new missing value, also
 updating the `missingval` field.
 """
-function replace_missing(a::AbstractGeoArray, newmissing=missing)
+replace_missing(a::DiskGeoArray, args...) = 
+    replace_missing(GeoArray(a), args...)
+replace_missing(a::MemGeoArray, newmissing=missing) = begin
     newdata = if ismissing(missingval(a))
         collect(Missings.replace(data(a), newmissing))
     else

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -1,5 +1,8 @@
 """
-A `AbstractSampled` (from DimensionalData.jl) with projections attached.
+    Projected(order::Order, span, sampling, crs, usercrs)
+    Projected(; order=Ordered(), span=UnknownSpan(), sampling=Points(), crs, usercrs=nothing)
+
+An `AbstractSampled` mode with projections attached.
 
 Fields and behaviours are identical to `Sampled` with the addition of
 `crs` and `usercrs` fields.
@@ -26,7 +29,7 @@ struct Projected{O<:Order,Sp,Sa,C,IC} <: AbstractSampled{O,Sp,Sa}
     usercrs::IC
 end
 Projected(; order=Ordered(), span=UnknownSpan(), 
-              sampling=Points(), crs, usercrs=nothing) =
+          sampling=Points(), crs, usercrs=nothing) =
     Projected(order, span, sampling, crs, usercrs)
 
 crs(mode::Projected, dim) = crs(mode)
@@ -38,3 +41,65 @@ usercrs(mode::Projected) = mode.usercrs
 rebuild(g::Projected, order=order(g), span=span(g), 
         sampling=sampling(g), crs=crs(g), usercrs=usercrs(g)) =
     Projected(order, span, sampling, crs, usercrs)
+
+"""
+    Converted(order::Order, span, sampling, crs, dimcrs)
+    Converted(; order=Ordered(), span=UnknownSpan(), sampling=Points(), crs, dimcrs)
+
+An `AbstractSampled` mode with projections, where the dimension has already been converted
+to another projection as a vector, usually `EPSG(4326)`.
+
+Fields and behaviours are identical to `Sampled` with the addition of
+`crs` and `dimcrs` fields.
+
+The dimension will be indexed as for `Sampled`, but to save in another format the
+underlying projection will be used.
+
+```julia
+GDALarray(filename; usercrs=EPSG(4326))
+```
+
+The underlying `crs` will be detected by GDAL.
+
+If `usercrs` is not supplied (ie. `isa Nothing`), the base index will be shown on plots, 
+and selectors will need to use whatever format it is in.
+"""
+struct Converted{O<:Order,Sp,Sa,C,DC} <: AbstractSampled{O,Sp,Sa}
+    order::O
+    span::Sp
+    sampling::Sa
+    crs::C
+    dimcrs::DC
+end
+Converted(; order=Ordered(), span=UnknownSpan(), 
+          sampling=Points(), crs, dimcrs) =
+    Converted(order, span, sampling, crs, dimcrs)
+
+crs(mode::Converted, dim) = crs(mode)
+crs(mode::Converted) = mode.crs
+
+dimcrs(mode::Converted, dim) = dimcrs(mode)
+dimcrs(mode::Converted) = mode.dimcrs
+
+rebuild(g::Converted, order=order(g), span=span(g), 
+        sampling=sampling(g), crs=crs(g), dimcrs=dimcrs(g)) =
+    Converted(order, span, sampling, crs, dimcrs)
+
+"""
+    LatLon(order, span, sampling)
+    LatLon(; order=Ordered(), span=UnknownSpan(), sampling=Points())
+
+An `AbstractSampled` mode for standard latitude/longitude dimensions.
+"""
+struct LatLon{O<:Order,Sp,Sa} <: AbstractSampled{O,Sp,Sa}
+    order::O
+    span::Sp
+    sampling::Sa
+end
+LatLon(; order=Ordered(), span=UnknownSpan(), sampling=Points()) =
+    LatLon(order, span, sampling)
+
+crs(mode::LatLon, args...) = EPSG(4326)
+
+rebuild(g::LatLon, order=order(g), span=span(g), sampling=sampling(g)) =
+    LatLon(order, span, sampling)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,6 +1,23 @@
 using DimensionalData: refdims_title
 
-@recipe function f(A::GeoArray{T,3,<:Tuple{<:Lat,<:Lon,D}}) where {T,D}
+struct GeoPlot end
+
+
+# We only look at arrays with Lat/Lon here.
+# Otherwise they fall back to DimensionalData.jl recipes
+@recipe function f(A::AbstractGeoArray)
+    A = GeoArray(A)
+    if all(hasdim(A, (Lat(), Lon())))
+        GeoPlot(), A
+    else
+        println("DimPlot")
+        da = A |> GeoArray |> a -> DimensionalArray(a; dims=maybe_reproject(dims(a)))
+        DimensionalData.DimensionalPlot(), da
+    end
+end
+
+# Plot 3d arrays as multiple tiled plots
+@recipe function f(::GeoPlot, A::GeoArray{T,3,<:Tuple{<:Lat,<:Lon,D}}) where {T,D}
     A = prepare(A)
     nplots = size(A, 3)
     if nplots > 1
@@ -12,50 +29,46 @@ using DimensionalData: refdims_title
                 aspect_ratio := 1
                 subplot := i
                 slice = A[:, :, i]
-                lat, lon = map(maybe_reproject, dims(A))
-                lon, lat, data(slice)
+                lat, lon = maybe_reproject(dims(A))
+                val(lon), val(lat), data(slice)
             end
         end
     else
-        A[:, :, 1]
+        println("1")
+        GeoPlot(), A[:, :, 1]
     end
 end
 
-# TODO generalise for any dimension order
-@recipe function f(A::GeoArray{T,3}) where {T,D}
-    if all(hasdim(A, (Lat, Lon)))
-        permutedims(A, (Lat, Lon, Dimension))
-    else
-        error("Cannot plot 3 dimensional GeoArray without both Lat/Lon dims")
-    end
+# # Permute for correct Lat/Lon order
+@recipe function f(::GeoPlot, A::GeoArray{T,3}) where {T}
+    GeoPlot(), permutedims(A, (Lat, Lon, Dimension))
 end
 
-@recipe function f(A::GeoArray{T,2,<:Tuple{<:Lat,<:Lon}}) where T
+# # Plot a sinlge 2d map
+@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:Lat,<:Lon}}) where T
     A = prepare(A)
     :seriestype --> :heatmap
     :aspect_ratio --> 1
-    :grid --> false
     :colorbar_title --> name(A)
     :title --> refdims_title(A)
-    lat, lon = map(maybe_reproject, dims(A, (Lat, Lon)))
-    lon, lat, data(A)
+    lat, lon = maybe_reproject(dims(A))
+    val(lon), val(lat), data(A)
 end
 
-@recipe function f(A::GeoArray{T,2,<:Tuple{<:Lon,<:Lat}}) where T
-    permutedims(A)
+# # Permute for correct Lat/Lon order
+@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:Lon,<:Lat}}) where T
+    GeoPlot(), permutedims(A)
 end
 
-@recipe function f(A::AbstractGeoArray)
-    GeoArray(A)
-end
-
+maybe_reproject(dims::Tuple) = map(maybe_reproject, dims)
 maybe_reproject(dim::Dimension) = maybe_reproject(mode(dim), dim)
-maybe_reproject(mode::IndexMode, dim::Dimension) = val(dim)
+maybe_reproject(mode::IndexMode, dim::Dimension) = dim
 maybe_reproject(mode::Projected, dim::Dimension) =
     maybe_reproject(crs(mode), usercrs(mode), dim)
-maybe_reproject(crs, usercrs, dim::Dimension) = val(dim)
-maybe_reproject(crs::GeoFormat, usercrs::GeoFormat, dim::Dimension) =
-    reproject(crs, usercrs, dim, val(dim))
+maybe_reproject(crs, usercrs, dim::Dimension) = dim
+maybe_reproject(crs::GeoFormat, usercrs::GeoFormat, dim::Dimension) = begin
+    rebuild(dim, reproject(crs, usercrs, dim, val(dim)))
+end
 
 prepare(A) = A |> forwardorder |> maybenanmissing
 

--- a/src/reproject.jl
+++ b/src/reproject.jl
@@ -21,19 +21,19 @@ a single dimension at a time.
 """
 reproject(source, target, dim::Dimension, val) = val
 reproject(source::GeoFormat, target::GeoFormat, dim::Lon, val::Number) =
-    ArchGDAL.reproject((Float64(val), 0.0), source, target)[1]
+    ArchGDAL.reproject((Float64(val), 0.0), source, target; order=:trad)[1]
 reproject(source::GeoFormat, target::GeoFormat, dim::Lat, val::Number) =
-    ArchGDAL.reproject((0.0, Float64(val)), source, target)[2]
+    ArchGDAL.reproject((0.0, Float64(val)), source, target; order=:trad)[2]
 
 reproject(source::GeoFormat, target::GeoFormat, ::Lon, vals::AbstractArray) =
-    [r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target)]
+    [r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target; order=:trad)]
 reproject(source::GeoFormat, target::GeoFormat, dim::Lat, vals::AbstractArray) =
-    [r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target)]
+    [r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target; order=:trad)]
 
 reproject(source::GeoFormat, target::GeoFormat, ::Lon, vals::Tuple) =
-    Tuple(r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target))
+    Tuple(r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target; order=:trad))
 reproject(source::GeoFormat, target::GeoFormat, dim::Lat, vals::Tuple) =
-    Tuple(r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target))
+    Tuple(r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target; order=:trad))
 
 
 convertmode(dstmode::Type{<:IndexMode}, dim::Dimension) = 

--- a/src/reproject.jl
+++ b/src/reproject.jl
@@ -15,14 +15,41 @@ sel2indices(mode::Projected, dim::Dimension, sel::Between) = begin
     DD.between(dim, rebuild(sel, selval))
 end
 
+"""
+`reproject` uses ArchGDAL.reproject, but implemented for a reprojecting 
+a single dimension at a time.
+"""
 reproject(source, target, dim::Dimension, val) = val
-
 reproject(source::GeoFormat, target::GeoFormat, dim::Lon, val::Number) =
-    ArchGDAL.reproject([(zero(val), val)], source, target)[1][1]
+    ArchGDAL.reproject((Float64(val), 0.0), source, target)[1]
 reproject(source::GeoFormat, target::GeoFormat, dim::Lat, val::Number) =
-    ArchGDAL.reproject([(val, zero(val))], source, target)[1][2]
+    ArchGDAL.reproject((0.0, Float64(val)), source, target)[2]
 
 reproject(source::GeoFormat, target::GeoFormat, ::Lon, vals::AbstractArray) =
-    [r[2] for r in ArchGDAL.reproject([(v, 0.0) for v in vals], source, target)]
+    [r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target)]
 reproject(source::GeoFormat, target::GeoFormat, dim::Lat, vals::AbstractArray) =
-    [r[1] for r in ArchGDAL.reproject([(0.0, v) for v in vals], source, target)]
+    [r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target)]
+
+reproject(source::GeoFormat, target::GeoFormat, ::Lon, vals::Tuple) =
+    Tuple(r[1] for r in ArchGDAL.reproject([(Float64(v), 0.0) for v in vals], source, target))
+reproject(source::GeoFormat, target::GeoFormat, dim::Lat, vals::Tuple) =
+    Tuple(r[2] for r in ArchGDAL.reproject([(0.0, Float64(v)) for v in vals], source, target))
+
+
+convertmode(dstmode::Type{<:IndexMode}, dim::Dimension) = 
+    convertmode(dstmode, basetypeof(mode(dim)), dim)
+convertmode(dstmode::Type{M}, srcmode::Type{M}, dim) where M = dim
+convertmode(dstmode::Type{Converted}, srcmode::Type{Projected}, dim) where M = begin
+    m = mode(dim)
+    newval = reproject(crs(m), usercrs(m), dim, val(dim))
+    newbounds = reproject(crs(m), usercrs(m), dim, bounds(dim))
+    newmode = Converted(order(m), Irregular(newbounds), sampling(m), crs(m), usercrs(m))
+    rebuild(dim; val=newval, mode=newmode)
+end
+convertmode(dstmode::Type{Projected}, srcmode::Type{Converted}, dim) where M = begin
+    m = mode(dim)
+    start, stop = reproject(dimcrs(m), crs(m), dim, [first(dim), last(dim)])
+    newval = LinRange(start, stop, length(dim))
+    newmode = Projected(order(m), Regular(step(newval)), sampling(m), crs(m), dimcrs(m))
+    rebuild(dim; val=newval, mode=newmode)
+end

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -98,8 +98,11 @@ end
 
 # AbstractGeoStack methods
 
-GDALstack(filename; kwargs...) = 
-    DiskStack(filename; childtype=GDALarray, kwargs...)
+GDALstack(filename; kwargs...) = begin
+    s = DiskStack(filename; childtype=GDALarray, kwargs...)
+    println(s.kwargs)
+    s
+end
 
 withsource(f, ::Type{<:GDALarray}, filename::AbstractString, key...) =
     gdalread(f, filename)
@@ -114,7 +117,6 @@ dims(dataset::AG.Dataset, usercrs=nothing) = begin
     catch
         GDAL_EMPTY_TRANSFORM
     end
-    println(gt)
 
     latsize, lonsize = AG.height(dataset), AG.width(dataset)
 

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -85,7 +85,7 @@ end
 
 missingval(grd::GrdAttrib{T}) where T = begin
     mv = try 
-        parse(Number, grd.attrib["nodatavalue"])
+        parse(T, grd.attrib["nodatavalue"])
     catch
         @warn "No data value from GDAL $(missingval) is not convertible to data type $T. `missingval` set to NaN."
         missing
@@ -220,7 +220,7 @@ Base.write(filename::String, ::Type{<:GrdArray}, A::AbstractGeoArray) = begin
             projection= $proj
             [data]
             datatype= $datatype
-            nodatavalue= 
+            nodatavalue= $nodatavalue
             byteorder= little
             nbands= $nbands
             minvalue= $minvalue

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -83,7 +83,14 @@ metadata(grd::GrdAttrib, args...) = begin
     metadata
 end
 
-missingval(grd::GrdAttrib{T}) where T = parse(T, grd.attrib["nodatavalue"])
+missingval(grd::GrdAttrib{T}) where T = begin
+    mv = try 
+        parse(Number, grd.attrib["nodatavalue"])
+    catch
+        @warn "No data value from GDAL $(missingval) is not convertible to data type $T. `missingval` set to NaN."
+        missing
+    end
+end
 
 name(grd::GrdAttrib) = get(grd.attrib, "layername", "")
 
@@ -213,7 +220,7 @@ Base.write(filename::String, ::Type{<:GrdArray}, A::AbstractGeoArray) = begin
             projection= $proj
             [data]
             datatype= $datatype
-            nodatavalue= $nodatavalue
+            nodatavalue= 
             byteorder= little
             nbands= $nbands
             minvalue= $minvalue

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -54,19 +54,19 @@ dims(grd::GrdAttrib, usercrs=nothing) = begin
 
     latmode = Projected(
         order=Ordered(Forward(), Reverse(), Reverse()),
+        span=Regular(yspan),
+        sampling=Intervals(Start()),
+        crs=crs,
+        usercrs=usercrs,
+    )
+    lonmode = Projected(
+        order=Ordered(),
         span=Regular(xspan),
         sampling=Intervals(Start()),
         crs=crs,
         usercrs=usercrs,
     )
     lat = Lat(LinRange(ybounds[1], ybounds[2] - yspan, nrows), latmode, latlon_metadata)
-    lonmode = Projected(
-        order=Ordered(),
-        span=Regular(yspan),
-        sampling=Intervals(Start()),
-        crs=crs,
-        usercrs=usercrs,
-    )
     lon = Lon(LinRange(xbounds[1], xbounds[2] - xspan, ncols), lonmode, latlon_metadata)
     band = Band(1:nbands; mode=Categorical(Ordered()))
     lon, lat, band
@@ -185,7 +185,7 @@ Base.write(filename::String, ::Type{<:GrdArray}, A::AbstractGeoArray) = begin
     ncols, nrows = size(A)
     xmin, xmax = bounds(dims(A, Lon))
     ymin, ymax = bounds(dims(A, Lat))
-    proj = convert(String, crs(dims(A, Lat)))
+    proj = convert(String, convert(ProjString, crs(dims(A, Lat))))
     datatype = rev_datatype_translation[eltype(A)]
     nodatavalue = missingval(A)
     minvalue = minimum(filter(x -> x != missingval(A), data(A)))

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -94,7 +94,7 @@ data(s::MemGeoStack) = s.data
 data(s::MemGeoStack{<:NamedTuple}, key::Key) = data(s)[Symbol(key)]
 
 rebuild(s::T; data=data(s), refdims=refdims(s), window=window(s), 
-        metadata=metadata(s), kwargs...) where T<:MemGeoStack =
+        metadata=metadata(s), kwargs=kwargs(s)) where T<:MemGeoStack =
     basetypeof(T)(data, refdims, window, metadata, kwargs)
 
 getsource(s::MemGeoStack{<:NamedTuple}, args...) = data(s, args...)
@@ -123,7 +123,7 @@ Abstract supertype for all disk backed [`AbstractGeoStack`](@ref)s
 abstract type DiskGeoStack{T} <: AbstractGeoStack{T} end
 
 rebuild(s::T; data=filename(s), refdims=refdims(s), window=window(s), 
-        metadata=metadata(s), childtype=childtype(s), kwargs...) where T<:DiskGeoStack =
+        metadata=metadata(s), childtype=childtype(s), kwargs=kwargs(s)) where T<:DiskGeoStack =
     basetypeof(T)(data, refdims, window, metadata, childtype, kwargs)
 
 getsource(s::DiskGeoStack, args...) = filename(s, args...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,3 +26,26 @@ checkarrayorder(dim::Dimension, order::Order) = begin
 end
 
 cleankeys(keys) = Tuple(Symbol.(keys))
+
+shiftindexloci(dim::Dimension, locus::Locus) =
+    shiftindexloci(mode(dim), dim, locus)
+
+shiftindexloci(::IndexMode, dim::Dimension, ::Locus) =
+    val(dim)
+shiftindexloci(mode::AbstractSampled, dim::Dimension, locus::Locus) =
+    shiftindexloci(span(mode), sampling(mode), dim, locus)
+shiftindexloci(span::Span, sampling::Sampling, dim::Dimension, ::Locus) = begin
+    println(typeof(span), typeof(sampling))
+    val(dim)
+end
+# We only actually shift Regular Intervals.
+shiftindexloci(span::Regular, sampling::Intervals, dim::Dimension, destlocus::Locus) =
+    val(dim) .+ step(span) * offset(locus(sampling), destlocus)
+
+offset(::Start, ::Center) = 0.5
+offset(::Start, ::End) = 1
+offset(::Center, ::Start) = -0.5
+offset(::Center, ::End) = 0.5
+offset(::End, ::Start) = -1
+offset(::End, ::Center) = -0.5
+offset(::T, ::T) where T<:Locus = 0

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -1,0 +1,54 @@
+using GeoData, Test, ArchGDAL
+using GeoData: reproject, convertmode
+
+@testset "reproject" begin
+    cea = ProjString("+proj=cea +lon_0=0 +lat_ts=30 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0")
+    wktcea = convert(WellKnownText, cea)
+    projcea = convert(ProjString, cea)
+    wkt4326 = convert(WellKnownText, EPSG(4326))
+    proj4326 = convert(ProjString, EPSG(4326))
+
+    @test reproject(proj4326, cea, Lat(), -30.0) ≈ -3.658789324855012e6
+    @test reproject(wktcea, EPSG(4326), Lat(), -3.658789324855012e6) ≈ -30.0
+    @test all(reproject(projcea, wkt4326, Lat(), (-3.658789324855012e6,)) .≈ (-30.0,))
+    @test reproject(cea, proj4326, lat, [-3.658789324855012e6]) ≈ [-30.0]
+
+    @test reproject(proj4326, cea, Lon(), 180.0) ≈ 1.7367530445161372e7
+    @test reproject(cea, EPSG(4326), Lon(), 1.7367530445161372e7) ≈ 180.0
+    @test all(reproject(cea, wkt4326, Lon(), (1.7367530445161372e7)) .≈ (180.0,))
+    @test reproject(cea, proj4326, Lon(), [1.7367530445161372e7]) ≈ [180.0]
+end
+
+@testset "convertmode" begin
+    projces = ProjString("+proj=cea")
+    proj4326 = convert(ProjString, EPSG(4326))
+
+    lonstart, lonend = 0.5, 179.5
+    cealonstart, cealonend = reproject(proj4326, projcea, Lon(), [lonstart, lonend])
+    cealonrange = LinRange(cealonstart, cealonend, 180)
+    lon = Lon(cealonrange; mode=Projected(Ordered(), Regular(step(cealonrange)), 
+              Intervals(Center()), projcea, proj4326))
+    convertedlon = convertmode(Converted, lon)
+    @test all(bounds(convertedlon) .≈ (0.0, 180.0))
+    @test val(convertedlon) ≈ 0.5:179.5
+
+    projectedlon = convertmode(Projected, convertedlon)
+    @test val(projectedlon) ≈ val(lon)
+    @test all(isapprox.(bounds(projectedlon), bounds(lon); atol=1e-10))
+
+    # Lat in not linear
+    latbounds = -90.0, 90.0
+    ceabounds = reproject(proj4326, projcea, Lat(), latbounds)
+    # Vals are the bounding range without the end bound
+    cealatrange = LinRange(ceabounds..., 181)[1:180]
+    lat = Lat(cealatrange; mode=Projected(Ordered(), Regular(step(cealatrange)), 
+              Intervals(Start()), projcea, proj4326))
+    convertedlat = convertmode(Converted, lat)
+    @test first(convertedlat) ≈ -90.0 atol=1e-5
+    @test all(isapprox.(bounds(convertedlat), (-90.0, 90.0); atol=1e-5))
+    @test val(lat) ≈ reproject(proj4326, projcea, Lat(), val(convertedlat))
+
+    projectedlat = convertmode(Projected, convertedlat)
+    @test val(projectedlat) ≈ val(lat)
+    @test all(bounds(projectedlat) .≈ bounds(lat))
+end

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -10,17 +10,17 @@ using GeoData: reproject, convertmode
 
     @test reproject(proj4326, cea, Lat(), -30.0) ≈ -3.658789324855012e6
     @test reproject(wktcea, EPSG(4326), Lat(), -3.658789324855012e6) ≈ -30.0
-    @test all(reproject(projcea, wkt4326, Lat(), (-3.658789324855012e6,)) .≈ (-30.0,))
-    @test reproject(cea, proj4326, lat, [-3.658789324855012e6]) ≈ [-30.0]
+    @test reproject(projcea, wkt4326, Lat(), -3.658789324855012e6) .≈ -30.0
+    @test reproject(cea, proj4326, Lat(), [-3.658789324855012e6]) ≈ [-30.0]
 
     @test reproject(proj4326, cea, Lon(), 180.0) ≈ 1.7367530445161372e7
     @test reproject(cea, EPSG(4326), Lon(), 1.7367530445161372e7) ≈ 180.0
-    @test all(reproject(cea, wkt4326, Lon(), (1.7367530445161372e7)) .≈ (180.0,))
+    @test reproject(cea, wkt4326, Lon(), 1.7367530445161372e7) .≈ 180.0
     @test reproject(cea, proj4326, Lon(), [1.7367530445161372e7]) ≈ [180.0]
 end
 
 @testset "convertmode" begin
-    projces = ProjString("+proj=cea")
+    projcea = ProjString("+proj=cea")
     proj4326 = convert(ProjString, EPSG(4326))
 
     lonstart, lonend = 0.5, 179.5
@@ -29,7 +29,7 @@ end
     lon = Lon(cealonrange; mode=Projected(Ordered(), Regular(step(cealonrange)), 
               Intervals(Center()), projcea, proj4326))
     convertedlon = convertmode(Converted, lon)
-    @test all(bounds(convertedlon) .≈ (0.0, 180.0))
+    @test all(isapprox.(bounds(convertedlon), (0.0, 180.0); atol=1e-10))
     @test val(convertedlon) ≈ 0.5:179.5
 
     projectedlon = convertmode(Projected, convertedlon)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 include("array.jl")
 include("stack.jl")
 include("series.jl")
+include("utils.jl")
+include("reproject.jl")
 include("aggregate.jl")
 include("methods.jl")
 # Only test SMAP locally for now

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -1,4 +1,4 @@
-using ArchGDAL, GeoData, Test, Statistics, Dates, Plots
+using ArchGDAL, GeoData, Test, Statistics, Dates, Plots, NCDatasets
 using GeoData: window, mode, span, sampling
 
 include(joinpath(dirname(pathof(GeoData)), "../test/test_utils.jl"))
@@ -20,7 +20,7 @@ path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
         @test length(val(dims(dims(gdalarray), Lon))) == 514
         @test ndims(gdalarray) == 3
         @test dims(gdalarray) isa Tuple{<:Lon,<:Lat,<:Band}
-        @test mode(dims(gdalarray, Band)) == Categorical(Ordered())
+        @test mode(dims(gdalarray, Band)) == DimensionalData.Categorical(Ordered())
         @test span.(mode.(dims(gdalarray, (Lat, Lon)))) == 
             (Regular(-60.02213698319351), Regular(60.02213698319374))
         @test sampling.(mode.(dims(gdalarray, (Lat, Lon)))) == 
@@ -161,7 +161,7 @@ path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
     @testset "plot" begin
         # TODO write some tests for this
         gdalarray |> plot
-        savefig("plot.png")
+        #savefig("plot.png")
     end
 
 end

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -5,7 +5,7 @@ include(joinpath(dirname(pathof(GeoData)), "../test/test_utils.jl"))
 
 path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
 
-@testset "array" begin
+@testset "GDALarray" begin
     gdalarray = GDALarray(path; usercrs=EPSG(4326), name="test");
 
     @testset "array properties" begin
@@ -14,7 +14,7 @@ path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
     end
 
     coord = first.(bounds(dims(gdalarray, (Lon, Lat))))
-    ArchGDAL.reproject([20, 20], EPSG(4326), ProjString("+proj=cea"))
+    ArchGDAL.reproject([20, 20], EPSG(4326), ProjString("+proj=cea"); order=:trad)
 
     @testset "dimensions" begin
         @test length(val(dims(dims(gdalarray), Lon))) == 514
@@ -140,7 +140,7 @@ path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
 
 end
 
-@testset "stack" begin
+@testset "GDAL stack" begin
     gdalstack = GDALstack((a=path, b=path));
 
     @testset "child array properties" begin
@@ -208,7 +208,7 @@ end
 
 end
 
-@testset "series" begin
+@testset "GDAL series" begin
     series = GeoSeries([path, path], (Ti,); childtype=GDALarray, usercrs=EPSG(4326), name="test")
     @test GeoArray(series[Ti(1)]) == GeoArray(GDALarray(path; usercrs=EPSG(4326), name="test"))
 end

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -9,7 +9,7 @@ path = joinpath(testpath, "data/rlogo")
 @test isfile(path * ".grd")
 @test isfile(path * ".gri")
 
-@testset "array" begin
+@testset "Grd array" begin
     grdarray = GrdArray(path);
 
     @testset "array properties" begin
@@ -120,6 +120,18 @@ path = joinpath(testpath, "data/rlogo")
             @test saved isa typeof(geoarray)
             @test data(saved) == data(geoarray)
         end
+        @test "netcdf" begin
+            filename2 = tempname()
+            write(filename2, NCDarray, grdarray[Band(1)])
+            saved = GeoArray(NCDarray(filename2))
+            @test size(saved) == size(grdarray[Band(1)])
+            @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
+            @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
+            @test val(dims(saved, Lon)) == val(dims(grdarray, Lon))
+            @test val(dims(saved, Lat)) == val(dims(grdarray, Lat))
+            @test bounds(saved, Lat) == bounds(grdarray, Lat)
+            @test bounds(saved, Lon) == bounds(grdarray, Lon)
+        end
     end
 
     @testset "plot" begin
@@ -128,7 +140,7 @@ path = joinpath(testpath, "data/rlogo")
 
 end
 
-@testset "stack" begin
+@testset "Grd stack" begin
     grdstack = GrdStack((a=path, b=path))
 
     @testset "indexing" begin
@@ -196,7 +208,7 @@ end
 
 end
 
-@testset "series" begin
+@testset "Grd series" begin
     series = GeoSeries([path, path], (Ti,); childtype=GrdArray, usercrs=EPSG(4326), name="test")
     @test GeoArray(series[Ti(1)]) == 
         GeoArray(GrdArray(path; usercrs=EPSG(4326), name="test"))

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -1,4 +1,4 @@
-using GeoData, Test, Statistics, Dates, Plots
+using GeoData, Test, Statistics, Dates, Plots, NCDatasets
 using GeoData: name, mode, window, DiskStack
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
@@ -120,15 +120,15 @@ path = joinpath(testpath, "data/rlogo")
             @test saved isa typeof(geoarray)
             @test data(saved) == data(geoarray)
         end
-        @test "netcdf" begin
+        @testset "to netcdf" begin
             filename2 = tempname()
             write(filename2, NCDarray, grdarray[Band(1)])
             saved = GeoArray(NCDarray(filename2))
             @test size(saved) == size(grdarray[Band(1)])
             @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
             @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
-            @test val(dims(saved, Lon)) == val(dims(grdarray, Lon))
-            @test val(dims(saved, Lat)) == val(dims(grdarray, Lat))
+            @test val(dims(saved, Lon)) ≈ val(dims(grdarray, Lon)) .+ 0.5
+            @test val(dims(saved, Lat)) ≈ val(dims(grdarray, Lat)) .+ 0.5
             @test bounds(saved, Lat) == bounds(grdarray, Lat)
             @test bounds(saved, Lon) == bounds(grdarray, Lon)
         end

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -203,7 +203,7 @@ end
 
 end
 
-@testset "series" begin
+@testset "NCD series" begin
     series = GeoSeries([ncmulti, ncmulti], (Ti,);
                        childtype=NCDstack, name="test")
     geoarray = GeoArray(NCDarray(ncmulti, :albedo; name="test"))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,22 @@
+using GeoData, Test
+using GeoData: cleankeys, shiftindexloci
+
+@testset "cleankeys" begin
+    @test cleankeys(["a", "b", "c"]) == (:a, :b, :c)
+    @test cleankeys(("a", "b", "c")) == (:a, :b, :c)
+end
+
+@testset "shiftindexloci" begin
+    dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(Center())))
+    @test shiftindexloci(dim, Start()) == 0.5:1.0:2.5
+    @test shiftindexloci(dim, End()) == 1.5:1.0:3.5
+    @test shiftindexloci(dim, Center()) == 1.0:1.0:3.0
+    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(Start())))
+    @test shiftindexloci(dim, End()) == [4, 5, 6]
+    @test shiftindexloci(dim, Center()) == [3.5, 4.5, 5.5]
+    @test shiftindexloci(dim, Start()) == [3, 4, 5]
+    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(End())))
+    @test shiftindexloci(dim, End()) == [3, 4, 5]
+    @test shiftindexloci(dim, Center()) == [2.5, 3.5, 4.5]
+    @test shiftindexloci(dim, Start()) == [2, 3, 4]
+end


### PR DESCRIPTION
This PR allows reading and writing between NCDatasets, ArchGDAL, and R grd files (and read from SMAP that can be written to anything).

- [x] read/write between R grd and GDAL
- [x] read/write between linear netcdf files to other formats
- [ ] read/write between projected netcdf and other formats (requires Alexander-Barth/NCDatasets.jl/issues/85)

closes #43 and #31