### PR TITLE
Bugfixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GeoData"
 uuid = "9b6fcbb8-86d6-11e9-1ce7-23a6bb139a78"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
-version = "0.1.2"
+version = "0.2.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -65,3 +65,32 @@ mean(A; dims=Band)
 ```
 """
 @dim Band
+
+
+
+"""
+    userbounds(x)
+
+Get the bounds converted to the `usercrs` value.
+
+Whithout ArchGDAL loaded, this is just the regular bounds.
+"""
+function userbounds end
+
+userbounds(A) = userbounds(dims(A)) 
+userbounds(dims::Tuple) = map(userbounds, dims) 
+userbounds(dim::Dimension) = bounds(dim)
+
+
+"""
+    userval(x)
+
+Get the index value of a dimension converted to the `usercrs` value.
+
+Whithout ArchGDAL loaded, this is just the regular dim value.
+"""
+function userval end
+
+userval(A) = userval(dims(A)) 
+userval(dims::Tuple) = map(userval, dims) 
+userval(dim::Dimension) = val(dim)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -2,7 +2,6 @@ using DimensionalData: refdims_title
 
 struct GeoPlot end
 
-
 # We only look at arrays with Lat/Lon here.
 # Otherwise they fall back to DimensionalData.jl recipes
 @recipe function f(A::AbstractGeoArray)
@@ -58,18 +57,12 @@ end
     GeoPlot(), permutedims(A)
 end
 
-maybe_reproject(dims::Tuple) = map(maybe_reproject, dims)
-maybe_reproject(dim::Dimension) = maybe_reproject(mode(dim), dim)
-maybe_reproject(mode::IndexMode, dim::Dimension) = dim
-maybe_reproject(mode::Projected, dim::Dimension) =
-    maybe_reproject(crs(mode), usercrs(mode), dim)
-maybe_reproject(crs, usercrs, dim::Dimension) = dim
-maybe_reproject(crs::GeoFormat, usercrs::GeoFormat, dim::Dimension) =
-    rebuild(dim, reproject(crs, usercrs, dim, val(dim)))
-
-
-# Plots heatmaps pixels are centered. So center, and use the projected value.
-preparedim(d) = shiftindexloci(Center(), d) |> maybe_reproject |> val
+# Plots heatmaps pixels are centered. 
+# So we should center, and use the projected value.
+# Except GDAL will wrap values that are shifted around 180, and break
+# plotting. Not sure of a robust way to fix this - so just ploting
+# as is for now. The error is only visible on very small arrays.
+preparedim(d) = userval(d) # shiftindexloci(Center(), d) |> userval
 
 # Convert arrays to a consistent missing value and Forward array order
 prepare(A) = A |> maybereplace_missing |> forwardorder

--- a/src/reproject.jl
+++ b/src/reproject.jl
@@ -53,28 +53,14 @@ convertmode(dstmode::Type{Projected}, srcmode::Type{Converted}, dim::Dimension) 
     rebuild(dim; val=newval, mode=newmode)
 end
 
-"""
-    userbounds(x)
 
-Get the bounds converted to the `usercrs` value.
-"""
-function userbounds end
-
-userbounds(A) = userbounds(dims(A)) 
-userbounds(dims::Tuple) = map(userbounds, dims) 
-userbounds(dim::Dimension) = bounds(dim)
-userbounds(dim::Union{Lat,Lon}) = 
+# Add Lat/Lon methods to reproject bounds and val
+userbounds(dim::Union{Lat,Lon}) = userbounds(mode(dim), dim) 
+userbounds(::Projected, dim::Union{Lat,Lon}) = 
     reproject(crs(dim), usercrs(dim), dim, bounds(dim)) 
+userbounds(::IndexMode, dim::Union{Lat,Lon}) = bounds(dim)
 
-"""
-    userval(x)
-
-Get the index value of a dimension converted to the `usercrs` value.
-"""
-function userval end
-
-userval(A) = userval(dims(A)) 
-userval(dims::Tuple) = map(userval, dims) 
-userval(dim::Dimension) = val(dim)
-userval(dim::Union{Lat,Lon}) = 
+userval(dim::Union{Lat,Lon}) = userval(mode(dim), dim)
+userval(::Projected, dim::Union{Lat,Lon}) = 
     reproject(crs(dim), usercrs(dim), dim, val(dim)) 
+userval(::IndexMode, dim::Union{Lat,Lon}) = val(dim)

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -61,17 +61,16 @@ ncwritevar!(dataset, A::AbstractGeoArray{T,N}) where {T,N} = begin
     for dim in dims(A)
         key = lowercase(name(dim))
         haskey(dataset.dim, key) && continue
-        
-        index = ncshiftindex(dim)
 
-        if dim isa Lat || dim isa Lon 
-            dim = convertmode(Converted, dim) 
+        if dim isa Lat || dim isa Lon
+            dim = convertmode(Converted, dim)
         end
+        index = ncshiftindex(dim)
         md = metadata(dim)
         attribvec = [] #md isa Nothing ? [] : [val(md)...]
         defDim(dataset, key, length(index))
         println("        key: \"", key, "\" of type: ", eltype(index))
-        defVar(dataset, key, index, (key,); attrib=attribvec)
+        defVar(dataset, key, Vector(index), (key,); attrib=attribvec)
     end
     # TODO actually convert the metadata type
     attrib = if metadata isa NCDarrayMetadata
@@ -93,7 +92,7 @@ ncwritevar!(dataset, A::AbstractGeoArray{T,N}) where {T,N} = begin
     key = if name(A) == ""
         UNNAMED_NCD_KEY
     else
-        name(A) 
+        name(A)
     end
     println("        key: \"", key, "\" of type: ", T)
     dimnames = lowercase.(name.(dims(A)))
@@ -104,20 +103,24 @@ ncwritevar!(dataset, A::AbstractGeoArray{T,N}) where {T,N} = begin
 end
 
 ncshiftindex(dim::Dimension) = ncshiftindex(mode(dim), dim)
-ncshiftindex(mode::AbstractSampled, dim::Dimension) =
-    if span(mode) isa Regular
-        if dim isa TimeDim 
-            if eltype(dim) isa Dates.AbstractDateTime
-                val(dim)
-            else
-                shiftindexloci(Start(), dim)
-            end
-        else
-            shiftindexloci(Center(), dim)
-        end
-    else
-        dim
-    end |> val
+ncshiftindex(mode::AbstractSampled, dim::Dimension) = val(dim)
+# As with plotting, we really should shift the index
+# to `Center`, but reprojection introduces errors
+    # if span(mode) isa Regular
+    #     # that are tricky to handle currently.
+    #     if dim isa TimeDim
+    #         if eltype(dim) isa Dates.AbstractDateTime
+    #             val(dim)
+    #         else
+    #             shiftindexloci(Center(), dim)
+    #         end
+    #     else
+    #         shiftindexloci(Center(), dim)
+    #     end
+    # else
+    #     dim
+    # end |> val
+
 ncshiftindex(mode::IndexMode, dim::Dimension) = val(dim)
 
 # CF standards don't enforce dimension names.
@@ -144,12 +147,12 @@ const dimmap = Dict("lat" => Lat,
 A [`DiskGeoArray`](@ref) that loads that loads NetCDF files lazily from disk.
 
 The first non-dimension layer of the file will be used as the array. Dims are usually
-detected as [`Lat`](@ref), [`Lon`](@ref), [`Ti`]($DDtidocs), and [`Vert`] or 
+detected as [`Lat`](@ref), [`Lon`](@ref), [`Ti`]($DDtidocs), and [`Vert`] or
 possibly `X`, `Y`, `Z` when detected. Undetected dims will use the generic `Dim{:name}`.
 
 This is an incomplete implementation of the NetCDF standard. It will currently
 handle simple files in lattitude/longitude projections, or projected formats
-if you manually specify `crs` and `dimcrs`. How this is done may also change in 
+if you manually specify `crs` and `dimcrs`. How this is done may also change in
 future, including detecting and converting the native NetCDF projection format.
 
 ## Arguments
@@ -158,16 +161,16 @@ future, including detecting and converting the native NetCDF projection format.
 
 ## Keyword arguments
 
-- `crs`: defaults to lat/lon `EPSG(4326)` but may be any `GeoFormat` like `WellKnownText`. 
-  If the underlying data is in a different projection `crs` will need to be set to allow 
+- `crs`: defaults to lat/lon `EPSG(4326)` but may be any `GeoFormat` like `WellKnownText`.
+  If the underlying data is in a different projection `crs` will need to be set to allow
   `write` to a different file format. In future this may be detected automatically.
-- `dimcrs`: The crs projection actually present in the Dimension index `Vector`, which 
+- `dimcrs`: The crs projection actually present in the Dimension index `Vector`, which
   may be different to the underlying projection. Defaults to lat/lon `EPSG(4326)` but
   may be any crs `GeoFormat`.
 - `name`: `String` name for the array. Will use array key if not supplied.
 - `dims`: `Tuple` of `Dimension`s for the array. Detected automatically, but can be passed in.
 - `refdims`: `Tuple of` position `Dimension`s the array was sliced from.
-- `missingval`: Value reprsenting missing values. Detected automatically when possible, but 
+- `missingval`: Value reprsenting missing values. Detected automatically when possible, but
   can be passed it.
 - `metadata`: [`Metadata`](@ref) object for the array. Detected automatically as
   [`NCDarrayMetadata`](@ref), but can be passed in.
@@ -238,13 +241,13 @@ Returns `filename`.
 """
 Base.write(filename::AbstractString, ::Type, A::AbstractGeoArray) = begin
     meta = metadata(A)
-    if meta isa Nothing
-        dataset = NCDatasets.Dataset(filename, "c")
-    else
+    # if meta isa Nothing
+    # else
         # Remove the dataset metadata
-        stackmd = pop!(deepcopy(val(meta)), "dataset", Dict())
-        dataset = NCDatasets.Dataset(filename, "c"; attrib=stackmd)
-    end
+        # stackmd = pop!(deepcopy(val(meta)), "dataset", Dict())
+    #    dataset = NCDatasets.Dataset(filename, "c"; attrib=stackmd)
+    # end
+    dataset = NCDatasets.Dataset(filename, "c")
     try
         println("    Writing netcdf...")
         ncwritevar!(dataset, A)
@@ -263,29 +266,29 @@ end
     NCDstack(files::NamedTuple; refdims=(), window=(), metadata=nothing, childkwargs=())
     NCDstack(filename::String; refdims=(), window=(), metadata=nothing, childkwargs=())
 
-A lazy [`AbstractGeoStack`](@ref) that uses NCDatasets.jl to load NetCDF files. 
-Can load a single multi-layer netcdf file, or multiple single-layer netcdf 
-files. In multi-file mode it returns a regular `GeoStack` with a `childtype` 
+A lazy [`AbstractGeoStack`](@ref) that uses NCDatasets.jl to load NetCDF files.
+Can load a single multi-layer netcdf file, or multiple single-layer netcdf
+files. In multi-file mode it returns a regular `GeoStack` with a `childtype`
 of [`NCDarray`](@ref).
 
-Indexing into `NCDstack` with layer keys (`Symbol`s) returns a [`GeoArray`](@ref). 
-Dimensions are usually detected as [`Lat`](@ref), [`Lon`](@ref), [`Ti`]($DDtidocs), 
+Indexing into `NCDstack` with layer keys (`Symbol`s) returns a [`GeoArray`](@ref).
+Dimensions are usually detected as [`Lat`](@ref), [`Lon`](@ref), [`Ti`]($DDtidocs),
 and [`Vert`] or `X`, `Y`, `Z` when detected. Undetected dims use the generic `Dim{:name}`.
 
 # Arguments
 
 - `filename`: `Tuple` or `Vector` or splatted arguments of `String`,
-  or single `String` path, to NetCDF files. 
+  or single `String` path, to NetCDF files.
 
 # Keyword arguments
 
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
   These default to the first non-dimension data key in each NetCDF file.
 - `refdims`: Add dimension position array was sliced from. Mostly used programatically.
-- `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the 
+- `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
   contained arrays when they are accessed.
 - `metadata`: A [`StackMetadata`](@ref) object.
-- `childkwargs`: A `NamedTuple` of keyword arguments to pass to the 
+- `childkwargs`: A `NamedTuple` of keyword arguments to pass to the
   [`NCDarray`](@ref) constructor.
 
 # Examples
@@ -320,7 +323,7 @@ NCDstack(files::NamedTuple;
          window=(),
          metadata=nothing,
          childkwargs=()) =
-    GeoStack(NamedTuple{keys}(filenames), refdims, window, metadata, 
+    GeoStack(NamedTuple{keys}(filenames), refdims, window, metadata,
              childtype=NCDarray, childkwargs)
 
 ncfilenamekeys(filenames) = cleankeys(ncread(ds -> first(nondimkeys(ds)), fn) for fn in filenames)
@@ -337,7 +340,7 @@ withsourcedata(f, ::Type{NCDarray}, path::AbstractString, key) =
 
 # Override the default to get the dims of the specific key,
 # and pass the crs and dimscrs from the stack
-dims(stack::NCDstack, dataset, key::Key) = 
+dims(stack::NCDstack, dataset, key::Key) =
     dims(dataset, key, crs(stack), dimcrs(stack))
 
 missingval(stack::NCDstack) = missing
@@ -352,7 +355,7 @@ Base.keys(stack::NCDstack{<:AbstractString}) =
 
 Write an NCDstack to a single netcdf file, using NCDatasets.jl.
 
-Currently [`DimMetadata`](@ref) is not handled, and [`ArrayMetadata`](@ref) 
+Currently [`DimMetadata`](@ref) is not handled, and [`ArrayMetadata`](@ref)
 from other [`AbstractGeoArray`](@ref) @types is ignored.
 """
 Base.write(filename::AbstractString, ::Type{<:NCDstack}, s::AbstractGeoStack) = begin

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,6 +32,8 @@ cleankeys(keys) = Tuple(Symbol.(keys))
 Shift the index from the current loci to the new loci. We only actually 
 shift Regular Intervals, and do this my multiplying the offset of 
 -1, -0.5, 0, 0.5 or 1 by the absolute value of the span.
+
+TODO: move this to DimensionalData.jl
 =#
 shiftindexloci(locus::Locus, dim::Dimension) = shiftindexloci(mode(dim), locus, dim)
 shiftindexloci(::IndexMode, ::Locus, dim::Dimension) = dim
@@ -39,7 +41,7 @@ shiftindexloci(mode::AbstractSampled, locus::Locus, dim::Dimension) =
     shiftindexloci(span(mode), sampling(mode), locus, dim)
 shiftindexloci(span::Span, sampling::Sampling, ::Locus, dim::Dimension) = dim
 shiftindexloci(span::Regular, sampling::Intervals, destlocus::Locus, dim::Dimension) =
-    rebuild(dim, val(dim) .+ abs(step(span)) * offset(locus(sampling), destlocus))
+    rebuild(dim, val(dim) .+ abs(step(span)) .* offset(locus(sampling), destlocus))
 
 offset(::Start, ::Center) = 0.5
 offset(::Start, ::End) = 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -41,7 +41,7 @@ shiftindexloci(mode::AbstractSampled, locus::Locus, dim::Dimension) =
     shiftindexloci(span(mode), sampling(mode), locus, dim)
 shiftindexloci(span::Span, sampling::Sampling, ::Locus, dim::Dimension) = dim
 shiftindexloci(span::Regular, sampling::Intervals, destlocus::Locus, dim::Dimension) =
-    rebuild(dim, val(dim) .+ abs(step(span)) .* offset(locus(sampling), destlocus))
+    rebuild(dim, val(dim) .+ (abs(step(span)) * offset(locus(sampling), destlocus)))
 
 offset(::Start, ::Center) = 0.5
 offset(::Start, ::End) = 1

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -155,10 +155,10 @@ path = geturl("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif")
             saved = GeoArray(NCDarray(filename2))
             @test size(saved) == size(gdalarray[Band(1)])
             @test saved ≈ reverse(gdalarray[Band(1)]; dims=Lat)
-            @test val(dims(saved, Lon)) ≈ val(dims(gdalarray, Lon)) .+ 0.5step(dims(saved, Lon))
-            @test val(dims(saved, Lat)) ≈ reverse(val(dims(gdalarray, Lat))) .+ 0.5step(dims(saved, Lat))
-            @test all(map(isapprox, bounds(saved, Lon), bounds(gdalarray, Lon)))
-            @test all(map(isapprox, bounds(saved, Lat), bounds(gdalarray, Lat)))
+            @test_broken val(dims(saved, Lon)) ≈ val(dims(gdalarray, Lon)) .+ 0.5step(dims(saved, Lon))
+            @test_broken val(dims(saved, Lat)) ≈ reverse(val(dims(gdalarray, Lat))) .+ 0.5step(dims(saved, Lat))
+            @test_broken all(map(isapprox, bounds(saved, Lon), bounds(gdalarray, Lon)))
+            @test_broken all(map(isapprox, bounds(saved, Lat), bounds(gdalarray, Lat)))
         end
 
     end

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -131,10 +131,10 @@ path = joinpath(testpath, "data/rlogo")
             @test size(saved) == size(grdarray[Band(1)])
             @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
             @test replace_missing(saved, missingval(grdarray)) ≈ reverse(grdarray[Band(1)]; dims=Lat)
-            @test val(dims(saved, Lon)) ≈ val(dims(grdarray, Lon)) .+ 0.5
-            @test val(dims(saved, Lat)) ≈ val(dims(grdarray, Lat)) .+ 0.5
-            @test bounds(saved, Lat) == bounds(grdarray, Lat)
-            @test bounds(saved, Lon) == bounds(grdarray, Lon)
+            @test_broken val(dims(saved, Lon)) ≈ val(dims(grdarray, Lon)) .+ 0.5
+            @test_broken val(dims(saved, Lat)) ≈ val(dims(grdarray, Lat)) .+ 0.5
+            @test_broken bounds(saved, Lat) == bounds(grdarray, Lat)
+            @test_broken bounds(saved, Lon) == bounds(grdarray, Lon)
         end
 
         @testset "to gdal" begin


### PR DESCRIPTION
Bugfix issues with plotting and conversion between netcdf and gdal etc.

The result of this PR is less accurate but more robust plotting and file conversion. The start/center position of the index in cells needs to be converted beteen gdal and netcdf, and gdal and plotting a heatmap. But converting the index then projecting is fragile and can break both plotting and saving files.

This needs to be done in a more robust way. Until then conversion plots tick marks may be 1/2 a cell off (rarely noticeable).

Files converted between gdal and netcdf will also be 1/2 a cell out of alignment in both lat and lon. This is more likely to be noticeable, especially when using `Between`, `Contains` and `bounds` as they will give slightly different results.

This PR also fixes incorrect NetCDF position of `Start` and `Intervals`, that should more often be `Center` and `Points`. It also attempts to parse the timespan length to `DatePeriod` if it exists, which is unfortunately less common than you would hope.
