### PR TITLE
Add resample wrapper and methods to convert between ArchGDAL.Dataset and GeoArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.jl.mem
 docs/build
 test/data
+Manifest.toml

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -65,7 +65,6 @@ include("methods.jl")
 include("mode.jl")
 include("sources/grd.jl")
 include("plotrecipes.jl")
-include("resample.jl")
 
 function __init__()
     @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" begin
@@ -76,6 +75,7 @@ function __init__()
         include("sources/ncdatasets.jl")
     end
     @require ArchGDAL="c9ce4bd3-c3d5-55b8-8973-c0e20141b8c3" begin
+        include("resample.jl")
         include("reproject.jl")
         include("sources/gdal.jl")
     end

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -24,8 +24,8 @@ using Base: tail
 using DimensionalData: Forward, Reverse, formatdims, slicedims, basetypeof,
       dims2indices, indexorder, arrayorder, relation, isrev
 
-import DimensionalData: val, data, dims, refdims, metadata, name, label, units, 
-       bounds, sel2indices, mode, order, locus, span, sampling, forwardorder, 
+import DimensionalData: val, data, dims, refdims, metadata, name, label, units,
+       bounds, sel2indices, mode, order, locus, span, sampling, forwardorder,
        rebuild, rebuildsliced, modify
 
 export Metadata, DimMetadata, ArrayMetadata, StackMetadata
@@ -65,7 +65,7 @@ include("methods.jl")
 include("mode.jl")
 include("sources/grd.jl")
 include("plotrecipes.jl")
-
+include("resample.jl")
 
 function __init__()
     @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" begin

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -19,7 +19,7 @@ export resample
 function resample(A::AbstractGeoArray, resolution::Number;
 				  crs::GeoFormat=crs(A),
                   method::String="near")
-    wkt = convert(String, convert(WellKnownText, proj))
+    wkt = convert(String, convert(WellKnownText, crs))
 
     AG.Dataset(A) do dataset
         AG.gdalwarp([dataset], ["-t_srs", "$(wkt)",

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,11 +1,12 @@
-function resample(A::GeoArray, proj::GeoFormat, resolution::Number;
-                  method::String = "near")
+function resample(A::AbstractGeoArray, resolution::Number;
+				  crs::GeoFormat=crs(A), 
+                  method::String="near")
     wkt = convert(String, convert(WellKnownText, proj))
 
     AG.Dataset(A) do dataset
         AG.gdalwarp([dataset], ["-t_srs", "$(wkt)",
-                                      "-tr", "$(resolution)", "$(resolution)",
-                                      "-r", "$(method)"]) do warped
+                                "-tr", "$(resolution)", "$(resolution)",
+                                "-r", "$(method)"]) do warped
             GeoArray(warped)
         end
     end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,0 +1,13 @@
+function resample(A::GeoArray, proj::GeoFormat, resolution::Number;
+                  method::String = "near")
+    wkt = convert(String, convert(WellKnownText, proj))
+
+    AG.Dataset(A) do dataset
+        AG.gdalwarp([dataset], ["-t_srs", "$(wkt)",
+                                      "-te_srs", "$(wkt)",
+                                      "-tr", "$(resolution)", "$(resolution)",
+                                      "-r", "$(method)"]) do warped
+            GeoArray(warped)
+        end
+    end
+end

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -4,7 +4,6 @@ function resample(A::GeoArray, proj::GeoFormat, resolution::Number;
 
     AG.Dataset(A) do dataset
         AG.gdalwarp([dataset], ["-t_srs", "$(wkt)",
-                                      "-te_srs", "$(wkt)",
                                       "-tr", "$(resolution)", "$(resolution)",
                                       "-r", "$(method)"]) do warped
             GeoArray(warped)

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,5 +1,23 @@
+export resample
+
+"""
+	resample(A::AbstractGeoArray, resolution::Number;
+			   crs::GeoFormat=crs(A),
+			   method::String="near")
+
+`resample` uses `ArchGDAL.gdalwarp` to resample an `AbstractGeoArray`.
+
+## Arguments
+- `A`: The `AbstractGeoArray` to resample.
+- `resolution`: A `Number` specifying the resolution for the output. If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
+
+## Keyword Arguments
+- `crs`: A `GeoFormatTypes.GeoFormat` specifying an output crs (`A` with be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
+- `method`: A `String` specifying the method to use for resampling. Defaults to `"near"` (nearest neighbor resampling). See [resampling method](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r) in the gdalwarp docs for a complete list of possible values.
+
+"""
 function resample(A::AbstractGeoArray, resolution::Number;
-				  crs::GeoFormat=crs(A), 
+				  crs::GeoFormat=crs(A),
                   method::String="near")
     wkt = convert(String, convert(WellKnownText, proj))
 

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -408,11 +408,11 @@ function unsafe_ArchGDALdataset(A::AbstractGeoArray)
     nbands = size(A, Band)
 
     dataset = AG.unsafe_create("tmp",
-                               driver = AG.getdriver("MEM"),
-                               width = width,
-                               height = height,
-                               nbands = nbands,
-                               dtype = eltype(A))
+                               driver=AG.getdriver("MEM"),
+                               width=width,
+                               height=height,
+                               nbands=nbands,
+                               dtype=eltype(A))
     # write bands to dataset
     AG.write!(dataset,
               data(permutedims(A, (Lon, Lat, Band))),

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -34,15 +34,15 @@ end
 # Array ########################################################################
 
 """
-    GDALarray(filename; 
-              usercrs=nothing, 
-              name="", 
-              dims=nothing, 
-              refdims=(), 
-              metadata=nothing, 
+    GDALarray(filename;
+              usercrs=nothing,
+              name="",
+              dims=nothing,
+              refdims=(),
+              metadata=nothing,
               missingval=nothing)
 
-Load a file lazily using gdal. `GDALarray` will be converted to [`GeoArray`](@ref) 
+Load a file lazily using gdal. `GDALarray` will be converted to [`GeoArray`](@ref)
 after indexing or other manipulations. `GeoArray(GDALarray(filename))` will do this
 immediately.
 
@@ -55,12 +55,12 @@ immediately.
 
 ## Keyword arguments
 
-- `usercrs`: CRS format like `EPSG(4326)` used in `Selectors` like `Between` and `At`, and 
+- `usercrs`: CRS format like `EPSG(4326)` used in `Selectors` like `Between` and `At`, and
   for plotting. Can be any CRS `GeoFormat` from GeoFormatTypes.jl, like `WellKnownText`.
 - `name`: `String` name for the array.
 - `dims`: `Tuple` of `Dimension`s for the array. Detected automatically, but can be passed in.
 - `refdims`: `Tuple of` position `Dimension`s the array was sliced from.
-- `missingval`: Value reprsenting missing values. Detected automatically when possible, but 
+- `missingval`: Value reprsenting missing values. Detected automatically when possible, but
   can be passed it.
 - `metadata`: [`Metadata`](@ref) object for the array. Detected automatically as
   [`GDALarrayMetadata`](@ref), but can be passed in.
@@ -86,15 +86,15 @@ end
 GDALarray(filename::AbstractString; kwargs...) = begin
     isfile(filename) || error("file not found: $filename")
     gdalread(filename) do raster
-        GDALarray(raster, filename; kwargs...) 
+        GDALarray(raster, filename; kwargs...)
     end
 end
-GDALarray(raster::AG.RasterDataset, filename, key=nothing; 
-          usercrs=nothing, 
-          dims=dims(raster, usercrs), 
+GDALarray(raster::AG.RasterDataset, filename, key=nothing;
+          usercrs=nothing,
+          dims=dims(raster, usercrs),
           refdims=(),
-          name="", 
-          metadata=metadata(raster), 
+          name="",
+          metadata=metadata(raster),
           missingval=missingval(raster)) = begin
     sze = size(raster)
     T = eltype(raster)
@@ -147,9 +147,9 @@ end
 """
     GDALstack(filenames; keys, kwargs...)
     GDALstack(filenames...; keys, kwargs...)
-    GDALstack(filenames::NamedTuple; 
-              window=(), 
-              metadata=nothing, 
+    GDALstack(filenames::NamedTuple;
+              window=(),
+              metadata=nothing,
               childkwargs=(),
               refdims=())
 
@@ -159,13 +159,13 @@ Load a stack of files lazily from disk.
 
 ## Arguments
 
-- `filenames`: A NamedTuple of stack keys and `String` filenames, or a `Tuple`, 
+- `filenames`: A NamedTuple of stack keys and `String` filenames, or a `Tuple`,
   `Vector` or splatted arguments of `String` filenames.
 
 ## Keyword arguments
 
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
-- `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the 
+- `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
   contained arrays when they are accessed.
 - `metadata`: Metadata as a [`StackMetadata`](@ref) object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
@@ -277,9 +277,9 @@ metadata(raster::AG.RasterDataset, args...) = begin
     offset = AG.getoffset(band)
     # norvw = AG.noverview(band)
     units = AG.getunittype(band)
-    path = first(AG.filelist(raster))
+    # path = first(AG.filelist(raster))
     meta = AG.metadata(raster.ds)
-    GDALarrayMetadata(Dict("filepath"=>path, "scale"=>scale, "offset"=>offset, "units"=>units))
+    GDALarrayMetadata(Dict("scale"=>scale, "offset"=>offset, "units"=>units))
 end
 
 # metadata(raster::RasterDataset, key) = begin
@@ -390,4 +390,67 @@ build_geotransform(lat, lon) = begin
     gt[GDAL_ROT2] = 0.0
     gt[GDAL_NS_RES] = step(lat)
     return gt
+end
+
+function GeoArray(dataset::AG.Dataset, key = nothing;
+                  usercrs = nothing,
+                  dims = dims(AG.RasterDataset(dataset), usercrs),
+                  refdims = (),
+                  name = "",
+                  metadata = metadata(AG.RasterDataset(dataset)),
+                  missingval = missingval(AG.RasterDataset(dataset)))
+    GeoArray(AG.read(dataset), dims, refdims, name, metadata, missingval)
+end
+
+function unsafe_ArchGDALdataset(A::GeoArray)
+    width = size(A, Lon)
+    height = size(A, Lat)
+    nbands = size(A, Band)
+
+    dataset = AG.unsafe_create("tmp",
+                               driver = AG.getdriver("MEM"),
+                               width = width,
+                               height = height,
+                               nbands = nbands,
+                               dtype = eltype(A))
+    # write bands to dataset
+    AG.write!(dataset,
+              data(permutedims(A, (Lon, Lat, Band))),
+              Cint[1:nbands...])
+
+    # set crs
+    wkt = convert(String, convert(WellKnownText, crs(A)))
+    AG.setproj!(dataset, wkt)
+
+    # set geotransform
+    # Set the index loci to the start of the cell for the lat and lon dimensions.
+    # NetCDF or other formats use the center of the interval, so they need conversion.
+    lon, lat = map(dims(A, (Lon(), Lat()))) do d
+        convertmode(Projected, d)
+    end
+    @assert indexorder(lat) == GDAL_LAT_ORDER
+    @assert indexorder(lon) == GDAL_LON_ORDER
+    lonindex, latindex = map((lon, lat)) do d
+        val(shiftindexloci(Start(), d))
+    end
+    # Get the geotransform from the updated lat/lon dims
+    geotransform = build_geotransform(latindex, lonindex)
+    AG.setgeotransform!(dataset, geotransform)
+
+    # Set the nodata value
+    miss_val = missingval(A)
+    for i in dims(A, Band).val
+        AG.setnodatavalue!(AG.getband(dataset, i), miss_val)
+    end
+
+    dataset
+end
+
+function AG.Dataset(f::Function, A::GeoArray)
+    dataset = unsafe_ArchGDALdataset(A)
+    try
+        f(dataset)
+    finally
+        AG.destroy(dataset)
+    end
 end

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -392,17 +392,17 @@ build_geotransform(lat, lon) = begin
     return gt
 end
 
-function GeoArray(dataset::AG.Dataset, key = nothing;
-                  usercrs = nothing,
-                  dims = dims(AG.RasterDataset(dataset), usercrs),
-                  refdims = (),
-                  name = "",
-                  metadata = metadata(AG.RasterDataset(dataset)),
-                  missingval = missingval(AG.RasterDataset(dataset)))
+function GeoArray(dataset::AG.Dataset, key=nothing;
+                  usercrs=nothing,
+                  dims=dims(AG.RasterDataset(dataset), usercrs),
+                  refdims=(),
+                  name="",
+                  metadata=metadata(AG.RasterDataset(dataset)),
+                  missingval=missingval(AG.RasterDataset(dataset)))
     GeoArray(AG.read(dataset), dims, refdims, name, metadata, missingval)
 end
 
-function unsafe_ArchGDALdataset(A::GeoArray)
+function unsafe_ArchGDALdataset(A::AbstractGeoArray)
     width = size(A, Lon)
     height = size(A, Lat)
     nbands = size(A, Band)
@@ -446,7 +446,7 @@ function unsafe_ArchGDALdataset(A::GeoArray)
     dataset
 end
 
-function AG.Dataset(f::Function, A::GeoArray)
+function AG.Dataset(f::Function, A::AbstractGeoArray)
     dataset = unsafe_ArchGDALdataset(A)
     try
         f(dataset)

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -96,7 +96,7 @@ GDALarray(raster::AG.RasterDataset, filename, key=nothing;
           usercrs=nothing,
           dims=dims(raster, usercrs),
           refdims=(),
-          name=Symbol(""), 
+          name=Symbol(""),
           metadata=metadata(raster),
           missingval=missingval(raster)) = begin
     sze = size(raster)
@@ -432,8 +432,8 @@ function unsafe_ArchGDALdataset(A::AbstractGeoArray)
     lon, lat = map(dims(A, (Lon(), Lat()))) do d
         convertmode(Projected, d)
     end
-    @assert indexorder(lat) == GDAL_LAT_ORDER
-    @assert indexorder(lon) == GDAL_LON_ORDER
+    @assert indexorder(lat) == GDAL_LAT_INDEX
+    @assert indexorder(lon) == GDAL_LON_INDEX
     lonindex, latindex = map((lon, lat)) do d
         val(shiftindexloci(Start(), d))
     end

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -396,7 +396,7 @@ build_geotransform(lat, lon) = begin
     return gt
 end
 
-function GeoArray(dataset::AG.Dataset, key=nothing;
+function GeoArray(dataset::AG.Dataset;
                   usercrs=nothing,
                   dims=dims(AG.RasterDataset(dataset), usercrs),
                   refdims=(),

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -277,9 +277,9 @@ metadata(raster::AG.RasterDataset, args...) = begin
     offset = AG.getoffset(band)
     # norvw = AG.noverview(band)
     units = AG.getunittype(band)
-    # path = first(AG.filelist(raster))
+    path = first(AG.filelist(raster))
     meta = AG.metadata(raster.ds)
-    GDALarrayMetadata(Dict("scale"=>scale, "offset"=>offset, "units"=>units))
+    GDALarrayMetadata(Dict("filepath"=>path, "scale"=>scale, "offset"=>offset, "units"=>units))
 end
 
 # metadata(raster::RasterDataset, key) = begin

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,6 +1,30 @@
 using GeoData, Test, ArchGDAL
+using GeoFormatTypes
 using GeoData: resample
 
 @testset "resample" begin
-    
+    download("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif", "data/cea.tif")
+
+    raster_path = "data/cea.tif"
+    output_res = 0.0027
+    output_crs = EPSG(4326)
+    resample_method = "near"
+
+    ## Resample cea.tif manually with ArchGDAL
+    wkt = convert(String, convert(WellKnownText, output_crs))
+    AG_output = ArchGDAL.read(raster_path) do dataset
+        ArchGDAL.gdalwarp([dataset], ["-t_srs", "$(wkt)",
+                                "-tr", "$(output_res)", "$(output_res)",
+                                "-r", "$(resample_method)"]) do warped
+            ArchGDAL.read(ArchGDAL.getband(warped, 1))
+        end
+    end
+
+    ## Resample cea.tif using resample
+    cea = GeoArray(GDALarray(raster_path))
+    GD_output = resample(cea, output_res, crs = output_crs, method = resample_method)
+
+    ## Compare the two
+    @test AG_output == GD_output.data[:, :, 1]
+    @test abs(step(dims(GD_output)[1])) ≈ abs(step(dims(GD_output)[2])) ≈ output_res
 end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -1,0 +1,6 @@
+using GeoData, Test, ArchGDAL
+using GeoData: resample
+
+@testset "resample" begin
+    
+end

--- a/test/resample.jl
+++ b/test/resample.jl
@@ -3,6 +3,7 @@ using GeoFormatTypes
 using GeoData: resample
 
 @testset "resample" begin
+    mkpath("data")
     download("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif", "data/cea.tif")
 
     raster_path = "data/cea.tif"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,11 +17,12 @@ include("set.jl")
 include("reproject.jl")
 include("aggregate.jl")
 include("methods.jl")
+include("resample.jl")
 # Only test SMAP locally for now
 if !haskey(ENV, "CI")
     include("sources/smap.jl")
 end
-if !Sys.iswindows() 
+if !Sys.iswindows()
     # GDAL Environment vars need to be set manually for windows, so skip for now
     include("sources/gdal.jl")
     include("sources/grd.jl")


### PR DESCRIPTION
Closes #68. Still a WIP -- no formal tests or docs yet, but can confirm that it is working for resampling a single-band raster from 1km resolution in a UTM projection (left panel in figure below) to 0.002&deg; in EPSG:4326 (right panel in figure below) :tada:. I think it should work for multi-band rasters. An edge case that would have errors would be if different bands have different NoData values, but I'm not sure if GeoData handles that to start.

I had some issues/trouble converting `ArchGDAL.Dataset`s and `RasterDataset`s to `GDALarray`s, so I just skipped the middle man since the `ArchGDAL.Dataset` is being created in memory anyway. I added a method to convert back and forth between `ArchGDAL.Dataset` and `GeoData.GeoArray`.

@rafaqz I wanted to give you a chance to review what I have so far before proceeding further.
|![image](https://user-images.githubusercontent.com/17304432/95651194-cec79500-0aa5-11eb-88af-ecfd1855785f.png) | ![image](https://user-images.githubusercontent.com/17304432/95651178-b788a780-0aa5-11eb-9ae9-ab177767b41b.png) |
|:-------:|:--------:|

