### PR TITLE
Snap resample

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
 ArchGDAL = "0.5"
-DimensionalData = "0.13"
+DimensionalData = "^0.13.3"
 GeoFormatTypes = "^0.2.1, 0.3"
 HDF5 = "0.13"
 Missings = "0.4"

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -2,29 +2,52 @@ export resample
 
 """
 	resample(A::AbstractGeoArray, resolution::Number;
-			   crs::GeoFormat=crs(A),
-			   method::String="near")
+			 crs::GeoFormat=crs(A), method::String="near")
+	resample(A::AbstractGeoArray, snap::AbstractGeoArray; method::String="near")
 
 `resample` uses `ArchGDAL.gdalwarp` to resample an `AbstractGeoArray`.
 
 ## Arguments
 - `A`: The `AbstractGeoArray` to resample.
-- `resolution`: A `Number` specifying the resolution for the output. If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
+- `resolution`: A `Number` specifying the resolution for the output. 
+  If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
+- `snap`: an `AbstractGeoArray` whos resolution, crs and bounds will be snapped to. 
+  For best results it should roughly cover the same extent, or a subset of `A`.
 
 ## Keyword Arguments
-- `crs`: A `GeoFormatTypes.GeoFormat` specifying an output crs (`A` with be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
-- `method`: A `String` specifying the method to use for resampling. Defaults to `"near"` (nearest neighbor resampling). See [resampling method](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r) in the gdalwarp docs for a complete list of possible values.
+- `crs`: A `GeoFormatTypes.GeoFormat` specifying an output crs 
+  (`A` with be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
+- `method`: A `String` specifying the method to use for resampling. Defaults to `"near"` 
+  (nearest neighbor resampling). See [resampling method](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r) 
+  in the gdalwarp docs for a complete list of possible values.
 
 """
+resample
+
 function resample(A::AbstractGeoArray, resolution::Number;
 				  crs::GeoFormat=crs(A),
                   method::String="near")
     wkt = convert(String, convert(WellKnownText, crs))
-
+    flags = ["-t_srs", "$(wkt)",
+             "-tr", "$(resolution)", "$(resolution)",
+             "-r", "$(method)"]
     AG.Dataset(A) do dataset
-        AG.gdalwarp([dataset], ["-t_srs", "$(wkt)",
-                                "-tr", "$(resolution)", "$(resolution)",
-                                "-r", "$(method)"]) do warped
+        AG.gdalwarp([dataset], flags) do warped
+            GeoArray(warped)
+        end
+    end
+end
+
+function resample(A::AbstractGeoArray, snap::AbstractGeoArray; method::String="near")
+    wkt = convert(String, convert(WellKnownText, crs(snap)))
+    latres, lonres = map(abs ∘ step, span(snap, (Lat(), Lon())))
+    (latmin, latmax), (lonmin, lonmax) = bounds(snap, (Lat(), Lon()))
+    flags = ["-t_srs", "$(wkt)",
+             "-tr", "$(latres)", "$(lonres)",
+             "-te", "$(lonmin)", "$(latmin)", "$(lonmax)", "$(latmax)",
+             "-r", "$(method)"]
+    AG.Dataset(A) do dataset
+        AG.gdalwarp([dataset], flags) do warped
             GeoArray(warped)
         end
     end

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -3,8 +3,8 @@ using GeoData: name, mode, window, DiskStack
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
 
-geturl("https://raw.githubusercontent.com/rspatial/raster/master/inst/external/rlogo.grd", "rlogo.grd")
-geturl("https://github.com/rspatial/raster/raw/master/inst/external/rlogo.gri", "rlogo.gri")
+maybedownload("https://raw.githubusercontent.com/rspatial/raster/master/inst/external/rlogo.grd", "rlogo.grd")
+maybedownload("https://github.com/rspatial/raster/raw/master/inst/external/rlogo.gri", "rlogo.gri")
 path = joinpath(testpath, "data/rlogo")
 @test isfile(path * ".grd")
 @test isfile(path * ".gri")

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -3,8 +3,8 @@ using GeoData: name, window, mode, span, sampling, val, Ordered
 include(joinpath(dirname(pathof(GeoData)), "../test/test_utils.jl"))
 
 ncexamples = "https://www.unidata.ucar.edu/software/netcdf/examples/"
-ncsingle = geturl(joinpath(ncexamples, "tos_O1_2001-2002.nc"))
-ncmulti = geturl(joinpath(ncexamples, "test_echam_spectral.nc"))
+ncsingle = maybedownload(joinpath(ncexamples, "tos_O1_2001-2002.nc"))
+ncmulti = maybedownload(joinpath(ncexamples, "test_echam_spectral.nc"))
 
 stackkeys = (
     :abso4, :aclcac, :aclcov, :ahfcon, :ahfice, :ahfl, :ahfliac, :ahfllac,
@@ -74,7 +74,7 @@ stackkeys = (
 
     @testset "indexing with reverse lat" begin
         if !haskey(ENV, "CI") # CI downloads fail. But run locally
-            ncrevlat = geturl("ftp://ftp.cdc.noaa.gov/Datasets/noaa.ersst.v5/sst.mon.ltm.1981-2010.nc")
+            ncrevlat = maybedownload("ftp://ftp.cdc.noaa.gov/Datasets/noaa.ersst.v5/sst.mon.ltm.1981-2010.nc")
             ncrevlatarray = NCDstack(ncrevlat; childkwargs=(missingval=-9.96921f36,))[:sst]
             @test order(dims(ncrevlatarray, Lat)) == Ordered(ReverseIndex(), ReverseArray(), ForwardRelation())
             @test ncrevlatarray[Lat(At(40)), Lon(At(100)), Ti(1)] == missingval(ncrevlatarray)

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,5 +1,5 @@
 # Loader for external sources
-geturl(url, filename=splitdir(url)[2]) = begin
+maybedownload(url, filename=splitdir(url)[2]) = begin
     dirpath = joinpath(dirname(pathof(GeoData)), "../test/data")
     mkpath(dirpath)
     filepath = joinpath(dirpath, filename) 


### PR DESCRIPTION
Add a method to `resample` that snaps one `AbstractGeoArray` to the crs, bounds and resolution of another `AbstractGeoArray`.

This also fixes a serious bug in `bounds` for gdal based GeoArrays. This is now tested against results from rasterio instead of manually calculated bounds.

Some refactors for gdal.jl are included.

@vlandau if you want to have a look at these changes that would be great :)

Sorry its a little annoying to read from moving things around. Most of the duplicated code from the last PR was put in `gdalsetproperties!` that is used for your MEM and the original GTIFF methods that create datasets.