### PR TITLE
Pretty printing for `AbstractGeoStack`

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -21,3 +21,28 @@ Base.show(io::IO, A::DiskGeoArray) = begin
     end
     print(io, "\n  From file: $(filename(A))")
 end
+
+function Base.show(io::IO, stack::AbstractGeoStack)
+    printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
+    print(io, " with $(length(keys(stack))) fields: $(stack.filename)\n")
+
+    for var in keys(stack)
+        printstyled(io, " $var", color=:green)
+
+        field_dims = dims(stack, var)
+        if length(field_dims) > 0
+            print(io, " with dimensions ")
+            for (d, dim) in enumerate(field_dims)
+                printstyled(io, "$(GeoData.name(dim))($(length(dim)))", color=:red)
+                d != length(field_dims) && printstyled(io, ", ", color=:red)
+            end
+        end
+        print(io, '\n')
+    end
+
+    n_metadata = length(stack.metadata)
+    if n_metadata > 0
+        print(io, "and $n_metadata metadata entries:\n")
+        show(io, stack.metadata)
+    end
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -25,7 +25,7 @@ end
 function Base.show(io::IO, stack::AbstractGeoStack)
     printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
     print(io, " with $(length(keys(stack))) field(s)")
-    applicable(filename, stack) && print(io, ": $(filename(stack))")
+    stack isa DiskGeoStack && print(io, ": $(filename(stack))")
     print(io, '\n')
 
     for var in keys(stack)
@@ -35,7 +35,8 @@ function Base.show(io::IO, stack::AbstractGeoStack)
         if length(field_dims) > 0
             print(io, " with dimension(s) ")
             for (d, dim) in enumerate(field_dims)
-                printstyled(io, "$(GeoData.name(dim))($(length(dim)))", color=:red)
+                printstyled(io, "$(name(dim))", color=:red)
+                print(io, " [length: $(length(dim))]")
                 d != length(field_dims) && print(io, ", ")
             end
         end
@@ -44,7 +45,7 @@ function Base.show(io::IO, stack::AbstractGeoStack)
 
     n_windows = length(stack.window)
     if n_windows > 0
-        print(io, "and with $n_windows window(s):\n")
+        print(io, "and with window:\n")
         for window in stack.window
             print(io, ' ')
             show(window)

--- a/src/show.jl
+++ b/src/show.jl
@@ -24,20 +24,30 @@ end
 
 function Base.show(io::IO, stack::AbstractGeoStack)
     printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
-    print(io, " with $(length(keys(stack))) fields: $(stack.filename)\n")
+    print(io, " with $(length(keys(stack))) field(s): $(stack.filename)\n")
 
     for var in keys(stack)
         printstyled(io, " $var", color=:green)
 
         field_dims = dims(stack, var)
         if length(field_dims) > 0
-            print(io, " with dimensions ")
+            print(io, " with dimension(s) ")
             for (d, dim) in enumerate(field_dims)
                 printstyled(io, "$(GeoData.name(dim))($(length(dim)))", color=:red)
-                d != length(field_dims) && printstyled(io, ", ", color=:red)
+                d != length(field_dims) && print(io, ", ")
             end
         end
         print(io, '\n')
+    end
+
+    n_windows = length(stack.window)
+    if n_windows > 0
+        print(io, "and with $n_windows window(s):\n")
+        for window in stack.window
+            print(io, ' ')
+            show(window)
+            print(io, '\n')
+        end
     end
 
     n_metadata = length(stack.metadata)

--- a/src/show.jl
+++ b/src/show.jl
@@ -53,6 +53,6 @@ function Base.show(io::IO, stack::AbstractGeoStack)
     n_metadata = length(stack.metadata)
     if n_metadata > 0
         print(io, "and $n_metadata metadata entries:\n")
-        show(io, stack.metadata)
+        display(stack.metadata)
     end
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -36,13 +36,18 @@ function Base.show(io::IO, stack::AbstractGeoStack)
         field_dims = dims(stack, var)
         n_dims = length(field_dims)
         dims_str = n_dims == 1 ? "dimension" : "dimensions"
+        print(io, " with $n_dims $dims_str: ")
         if n_dims > 0
-            print(io, " with $n_dims $dims_str: ")
             for (d, dim) in enumerate(field_dims)
                 printstyled(io, "$(name(dim))", color=:red)
-                print(io, " [length: $(length(dim))]")
                 d != length(field_dims) && print(io, ", ")
             end
+            print(io, " (size ")
+            for (d, dim) in enumerate(field_dims)
+                print(io, "$(length(dim))")
+                d != length(field_dims) && print(io, '×')
+            end
+            print(io, ')')
         end
         print(io, '\n')
     end

--- a/src/show.jl
+++ b/src/show.jl
@@ -23,8 +23,10 @@ Base.show(io::IO, A::DiskGeoArray) = begin
 end
 
 function Base.show(io::IO, stack::AbstractGeoStack)
+    n_fields = length(keys(stack))
+    fields_str = n_fields == 1 ? "field" : "fields"
     printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
-    print(io, " with $(length(keys(stack))) field(s)")
+    print(io, " with $n_fields $fields_str")
     stack isa DiskGeoStack && print(io, ": $(filename(stack))")
     print(io, '\n')
 
@@ -32,8 +34,10 @@ function Base.show(io::IO, stack::AbstractGeoStack)
         printstyled(io, " $var", color=:green)
 
         field_dims = dims(stack, var)
-        if length(field_dims) > 0
-            print(io, " with dimension(s) ")
+        n_dims = length(field_dims)
+        dims_str = n_dims == 1 ? "dimension" : "dimensions"
+        if n_dims > 0
+            print(io, " with $n_dims $dims_str: ")
             for (d, dim) in enumerate(field_dims)
                 printstyled(io, "$(name(dim))", color=:red)
                 print(io, " [length: $(length(dim))]")
@@ -55,8 +59,9 @@ function Base.show(io::IO, stack::AbstractGeoStack)
 
     if !isnothing(stack.metadata)
         n_metadata = length(stack.metadata)
+        entries_str = n_metadata == 1 ? "entry" : "entries"
         if n_metadata > 0
-            print(io, "and $n_metadata metadata entries:\n")
+            print(io, "and $n_metadata metadata $entries_str:\n")
             display(stack.metadata)
         end
     end

--- a/src/show.jl
+++ b/src/show.jl
@@ -24,7 +24,9 @@ end
 
 function Base.show(io::IO, stack::AbstractGeoStack)
     printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
-    print(io, " with $(length(keys(stack))) field(s): $(stack.filename)\n")
+    print(io, " with $(length(keys(stack))) field(s)")
+    applicable(filename, stack) && print(io, ": $(filename(stack))")
+    print(io, '\n')
 
     for var in keys(stack)
         printstyled(io, " $var", color=:green)
@@ -50,9 +52,11 @@ function Base.show(io::IO, stack::AbstractGeoStack)
         end
     end
 
-    n_metadata = length(stack.metadata)
-    if n_metadata > 0
-        print(io, "and $n_metadata metadata entries:\n")
-        display(stack.metadata)
+    if !isnothing(stack.metadata)
+        n_metadata = length(stack.metadata)
+        if n_metadata > 0
+            print(io, "and $n_metadata metadata entries:\n")
+            display(stack.metadata)
+        end
     end
 end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -389,3 +389,29 @@ Base.cat(stacks::AbstractGeoStack...; keys=keys(stacks[1]), dims) = begin
 end
 Base.first(s::AbstractGeoStack) = s[first(keys(s))]
 Base.last(s::AbstractGeoStack) = s[last(keys(s))]
+
+function Base.show(io::IO, stack::AbstractGeoStack)
+    printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
+    print(io, " with $(length(keys(stack))) fields: $(stack.filename)\n")
+
+    for var in keys(stack)
+        printstyled(io, " $var", color=:green)
+
+        if length(dims(stack[var])) > 0
+            print(io, " with dimensions ")
+            field_dims = dims(stack[var])
+            for (d, dim) in enumerate(field_dims)
+                printstyled(io, "$(GeoData.name(dim))($(length(dim)))", color=:red)
+                d != length(field_dims) && printstyled(io, ", ", color=:red)
+            end
+        end
+        print(io, '\n')
+    end
+
+    n_metadata = length(stack.metadata)
+    if n_metadata > 0
+        print(io, "and $n_metadata metadata entries:\n")
+        show(io, stack.metadata)
+    end
+end
+

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -389,29 +389,3 @@ Base.cat(stacks::AbstractGeoStack...; keys=keys(stacks[1]), dims) = begin
 end
 Base.first(s::AbstractGeoStack) = s[first(keys(s))]
 Base.last(s::AbstractGeoStack) = s[last(keys(s))]
-
-function Base.show(io::IO, stack::AbstractGeoStack)
-    printstyled(io, "$(Base.typename(typeof(stack)))", color=:blue)
-    print(io, " with $(length(keys(stack))) fields: $(stack.filename)\n")
-
-    for var in keys(stack)
-        printstyled(io, " $var", color=:green)
-
-        if length(dims(stack[var])) > 0
-            print(io, " with dimensions ")
-            field_dims = dims(stack[var])
-            for (d, dim) in enumerate(field_dims)
-                printstyled(io, "$(GeoData.name(dim))($(length(dim)))", color=:red)
-                d != length(field_dims) && printstyled(io, ", ", color=:red)
-            end
-        end
-        print(io, '\n')
-    end
-
-    n_metadata = length(stack.metadata)
-    if n_metadata > 0
-        print(io, "and $n_metadata metadata entries:\n")
-        show(io, stack.metadata)
-    end
-end
-

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -117,3 +117,12 @@ end
     catstack = cat(stack_a, stack_b; dims=(Lon(), Lat()))
     @test size(first(catstack)) == (20, 22)
 end
+
+@testset "show" begin
+    sh = sprint(show, stack)
+    # Test but don't lock this down too much
+    @test contains(sh, "GeoStack")
+    @test contains(sh, "Latitude")
+    @test contains(sh, "Longitude")
+end
+


### PR DESCRIPTION
Took a stab at defining a prettier `Base.show` method for `AbstractGeoStack`.

Before:

```julia
julia> using NCDatasets, GeoData

julia> ds = NCDstack("double_gyre.nc")
NCDstack{String,Tuple{},Tuple{},NCDstackMetadata{String,Any},Tuple{}}("double_gyre.nc", (), (), NCDstackMetadata{String,Any}(Pair{String,Any}("interval", 172800.0),Pair{String,Any}("Oceananigans", "This file was generated using Oceananigans v0.44.0#ali/named-tuple-netcdf"),Pair{String,Any}("Julia", "This file was generated using Julia Version 1.5.2\nCommit 539f3ce943 (2020-09-23 23:17 UTC)\nPlatform Info:\n  OS: Linux (x86_64-pc-linux-gnu)\n  CPU: Intel(R) Xeon(R) Silver 4214 CPU @ 2.20GHz\n  WORD_SIZE: 64\n  LIBM: libopenlibm\n  LLVM: libLLVM-9.0.1 (ORCJIT, cascadelake)\n  GPU: TITAN V\n"),Pair{String,Any}("output time interval", "Output was saved every 2 days."),Pair{String,Any}("date", "This file was generated on 2020-11-03T20:57:16.256."),Pair{String,Any}("schedule", "TimeInterval")), ())
```

This PR so far:

![image](https://user-images.githubusercontent.com/20099589/98174662-3b765980-1ec3-11eb-9bfe-6c79b18afc06.png)

# Two issues

1. Couldn't figure out how to pretty print the stack metadata. Was hoping for something more like

```julia
julia> ds.metadata
NCDstackMetadata{String,Any} with 6 entries:
  "interval"             => 172800.0
  "Oceananigans"         => "This file was generated using Oceananigans v0.44.0#ali/named-tuple-netcdf"
  "Julia"                => "This file was generated using Julia Version 1.5.2\nCommit 539f3ce943 (2020-09-23…
  "output time interval" => "Output was saved every 2 days."
  "date"                 => "This file was generated on 2020-11-03T20:57:16.256."
  "schedule"             => "TimeInterval"
```

2. Something is doing A LOT of allocating. I don't understand the GeoData.jl internals so I probably did something wrong...

```julia
julia> @time Base.show(stdout, ds);
3.202175 seconds (873.53 k allocations: 2.215 GiB, 7.48% gc time)
```