### PR TITLE
dont show DiskGeoArray data

### DIFF
--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -63,6 +63,7 @@ include("aggregate.jl")
 include("methods.jl")
 include("mode.jl")
 include("sources/grd.jl")
+include("show.jl")
 include("plotrecipes.jl")
 
 function __init__()

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,23 @@
+
+# Don't show the data in DiskGeoArray. It 
+# defeats the purpose of loading them lazily.
+Base.show(io::IO, A::DiskGeoArray) = begin
+    l = nameof(typeof(A))
+    printstyled(io, nameof(typeof(A)); color=:blue)
+    if label(A) != ""
+        print(io, " (named ")
+        printstyled(io, label(A); color=:blue)
+        print(io, ")")
+    end
+    print(io, " with dimensions:\n")
+    for d in dims(A)
+        print(io, " ", d, "\n")
+    end
+    if !isempty(refdims(A))
+        print(io, "and referenced dimensions:\n")
+        for d in refdims(A)
+            print(io, " ", d, "\n")
+        end
+    end
+    print(io, "\n  From file: $(filename(A))")
+end

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -7,8 +7,6 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
 
 @testset "GDALarray" begin
     gdalarray = GDALarray(path; usercrs=EPSG(4326), name=:test)
-    cat(gdalarray, gdalarray; dims=Band)
-    replace(GeoArray(gdalarray), -9999 => 0)
 
     @testset "array properties" begin
         @test size(gdalarray) == (514, 515, 1)
@@ -171,8 +169,9 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
         @test contains(sh, "Band")
     end
 
-    @testset "plot" begin # TODO write some tests for this
+    @testset "plot and show" begin # TODO write some tests for this
         gdalarray |> plot
+        gdalarray |> show
     end
 
 end


### PR DESCRIPTION
Lazy arrays stored on disk shouldn't be shown in the REPL.