### PR TITLE
add OpenGeoArray and do block behaviour

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,6 +22,7 @@ AbstractGeoArray
 MemGeoArray
 DiskGeoArray
 GeoArray
+Open
 ```
 
 ## Stack

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -29,7 +29,8 @@ import DimensionalData: val, data, dims, refdims, metadata, name, label, units,
 
 export Metadata, DimMetadata, ArrayMetadata, StackMetadata
 
-export AbstractGeoArray, MemGeoArray, DiskGeoArray, GeoArray
+export AbstractGeoArray, MemGeoArray, DiskGeoArray, GeoArray, Open
+
 export AbstractGeoStack, MemGeoStack, DiskGeoStack, DiskStack, GeoStack
 
 export AbstractGeoSeries, GeoSeries
@@ -62,6 +63,7 @@ include("series.jl")
 include("utils.jl")
 include("aggregate.jl")
 include("methods.jl")
+include("open.jl")
 include("sources/grd.jl")
 include("show.jl")
 include("plotrecipes.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -144,6 +144,30 @@ Base.write(filename::AbstractString, A::T) where T <: DiskGeoArray =
     write(filename, T, A)
 
 
+# Used internally to expose open disk files inside a `do` block
+struct OpenGeoArray{T,N,D<:Tuple,R<:Tuple,A,Na<:Symbol,Me,Mi} <: AbstractGeoArray{T,N,D,A}
+    data::A
+    dims::D
+    refdims::R
+    name::Na
+    metadata::Me
+    missingval::Mi
+end
+function OpenGeoArray(A, dims, refdims, name, metadata, missingval)
+    OpenGeoArray{eltype(A),ndims(A),map(typeof,(dims,refdims,A,name,metadata,missingval))...}(
+        A, dims, refdims, name, metadata, missingval
+    )
+end
+function OpenGeoArray(f, A::X) where {X<:DiskGeoArray{T,N}} where {T,N}
+    withsourcedata(A) do source
+        OA = OpenGeoArray(source, dims(A), refdims(A), name(A), metadata(A), missingval(A))
+        f(OA)
+    end
+end
+
+# operate on an AbstractGeoArray in a method or `do` block
+(A::AbstractGeoArray)(f) = OpenGeoArray(f, A)
+
 # Concrete implementation ######################################################
 
 """

--- a/src/open.jl
+++ b/src/open.jl
@@ -1,0 +1,45 @@
+
+# Used internally to expose open disk files inside a `do` block
+struct OpenGeoArray{T,N,D<:Tuple,R<:Tuple,A,Na<:Symbol,Me,Mi} <: AbstractGeoArray{T,N,D,A}
+    data::A
+    dims::D
+    refdims::R
+    name::Na
+    metadata::Me
+    missingval::Mi
+end
+function OpenGeoArray(A, dims, refdims, name, metadata, missingval)
+    OpenGeoArray{eltype(A),ndims(A),map(typeof,(dims,refdims,A,name,metadata,missingval))...}(
+        A, dims, refdims, name, metadata, missingval
+    )
+end
+function OpenGeoArray(f, A::AbstractGeoArray{T,N}) where {T,N}
+    withsourcedata(A) do source
+        OA = OpenGeoArray(source, dims(A), refdims(A), name(A), metadata(A), missingval(A))
+        f(OA)
+    end
+end
+
+"""
+    open(f, A::AbstractGeoArray)
+
+`Open` is used to open any `AbstractGeoArray` and do multiple operations
+on it in a safe way. It's a shorthand for the unexported `OpenGeoArray`
+constructor.
+
+`f` is a method that accepts a single argument - an `OpenGeoArray` object
+which is just an `AbstractGeoArray` that holds an open disk - based object. 
+Often it will be a `do` block: 
+
+```julia
+ga = GDALarray(filepath)
+Open(ga) do A
+    A[I...] # A is an `OpenGeoArray` wrapping the disk-based object. 
+    # ...  multiple things you need to do with the open file
+end
+```
+
+By using a do block to open file we ensure they are always closed again
+after we finish working with them.
+"""
+Open(f, A::AbstractGeoArray) = OpenGeoArray(f, A)

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -8,6 +8,10 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
 @testset "GDALarray" begin
     gdalarray = GDALarray(path; mappedcrs=EPSG(4326), name=:test)
 
+    @testset "open" begin
+        @test Open(A -> A[Lat=1], gdalarray) == gdalarray[:, 1, :]
+    end
+
     @testset "array properties" begin
         @test size(gdalarray) == (514, 515, 1)
         @test gdalarray isa GDALarray{UInt8,3}

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -13,7 +13,7 @@ path = joinpath(testpath, "data/rlogo")
     grdarray = GRDarray(path);
 
     @testset "open" begin
-        @test all(grdarray(A -> A[Lat=1]) .=== grdarray[:, 1, :])
+        @test all(Open(A -> A[Lat=1], grdarray) .=== grdarray[:, 1, :])
     end
 
     @testset "array properties" begin

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -12,6 +12,10 @@ path = joinpath(testpath, "data/rlogo")
 @testset "Grd array" begin
     grdarray = GRDarray(path);
 
+    @testset "open" begin
+        @test all(grdarray(A -> A[Lat=1]) .=== grdarray[:, 1, :])
+    end
+
     @testset "array properties" begin
         @test grdarray isa GRDarray{Float32,3}
     end

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -27,6 +27,10 @@ stackkeys = (
 @testset "NCDarray" begin
     ncarray = NCDarray(ncsingle)
 
+    @testset "open" begin
+        @test all(ncarray(A -> A[Lat=1]) .=== ncarray[:, 1, :])
+    end
+
     @testset "array properties" begin
         @test size(ncarray) == (180, 170, 24)
         @test ncarray isa NCDarray

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -28,7 +28,7 @@ stackkeys = (
     ncarray = NCDarray(ncsingle)
 
     @testset "open" begin
-        @test all(ncarray(A -> A[Lat=1]) .=== ncarray[:, 1, :])
+        @test all(Open(A -> A[Lat=1], ncarray) .=== ncarray[:, 1, :])
     end
 
     @testset "array properties" begin


### PR DESCRIPTION
This adds an function/do-block syntax to all `AbstractGeoArray` objects:

```julia
ga = GDALarray(filepath)
ga() do A
    A[I...] # A is a OpenGeoArray with the disk based object loaded underneath. 
    # ...  multiple things you need to do with the open file
end
# It's automatically closed outside of the do block
```

@maxfreu This will probably perform better. There is some type instability do deal with too, guess it's time to start to `@profile` everything and lock all of this down.

In the case above `parent(A)` is the `RasterDataset` object. But you can index into `A` using lat/lon etc if you need to.