### PR TITLE
use key2dim to filter netcdf dimension names

### DIFF
--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -13,11 +13,7 @@ end
 
 """
     NCDarrayMetadata(val::Dict)
-
-[`Metadata`](@ref) wrapper for [`NCDarray`](@ref) metadata.
-"""
-struct NCDarrayMetadata{K,V} <: ArrayMetadata{K,V}
-    val::Dict{K,V}
+[`Metadata`](@ref) wrapper for [`NCDarray`](@ref) metadata.  """ struct NCDarrayMetadata{K,V} <: ArrayMetadata{K,V} val::Dict{K,V}
 end
 
 """
@@ -124,7 +120,7 @@ ncshiftindex(mode::IndexMode, dim::Dimension) = val(dim)
 
 # CF standards don't enforce dimension names.
 # But these are common, and should take care of most dims.
-const dimmap = Dict("lat" => Lat,
+const DIMMAP = Dict("lat" => Lat,
                     "latitude" => Lat,
                     "lon" => Lon,
                     "long" => Lon,
@@ -379,7 +375,7 @@ dims(dataset::NCDatasets.Dataset, key::Key, crs=nothing, dimcrs=nothing) = begin
             dvar = dataset[dimname]
             # Find the matching dimension constructor. If its an unknown name use
             # the generic Dim with the dim name as type parameter
-            dimtype = get(dimmap, dimname, Dim{Symbol(dimname)})
+            dimtype = haskey(DIMMAP, dimname) ? DIMMAP[dimname] : basetypeof(DD.key2dim(Symbol(dimname)))
             index = dvar[:]
             meta = NCDdimMetadata(Dict{String,Any}(dvar.attrib))
             mode = _ncdmode(index, dimtype, crs, dimcrs, meta)


### PR DESCRIPTION
@ali-ramadhan see if this branch works for you.

My list of default netcdf dimension names is also fairly arbitrary - I don't know of a clear spec on what they should be called in netcdf. 

This PR just means if the name isn't a default name, it will use `key2dim` which should find your custom dims, and if not it will use `Dim{:somediim}`. 

As the syntax for `Dim{:X}` dims is much better than it used to be, we could almost get rid of the `@dim` dims and use traits on `Dim{:x}` for plotting, instead of inheritance from `XDim`, `YDim` it would be `isxdim(dim::Dim{:X}) = true`. etc. 