### PR TITLE
Dont show AbstractGeoArray data

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -16,5 +16,5 @@ Base.show(io::IO, A::AbstractGeoArray) = begin
             print(io, " ", d, "\n")
         end
     end
-    applicable(filename, A) && print(io, "\n  From file: $(filename(A))")
+    A isa DiskGeoArray && print(io, "\n  From file: $(filename(A))")
 end

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,7 +1,4 @@
-
-# Don't show the data in DiskGeoArray. It 
-# defeats the purpose of loading them lazily.
-Base.show(io::IO, A::DiskGeoArray) = begin
+Base.show(io::IO, A::AbstractGeoArray) = begin
     l = nameof(typeof(A))
     printstyled(io, nameof(typeof(A)); color=:blue)
     if label(A) != ""
@@ -19,5 +16,5 @@ Base.show(io::IO, A::DiskGeoArray) = begin
             print(io, " ", d, "\n")
         end
     end
-    print(io, "\n  From file: $(filename(A))")
+    applicable(filename, A) && print(io, "\n  From file: $(filename(A))")
 end


### PR DESCRIPTION
Hopefully I did it right.

I just dispatched on `::AbstractGeoArray` and seemed like printing `filename(A)` does not work for `MemGeoArray` so I only printed the filename is `applicable(filename, A)`.

Resolves #94 