### PR TITLE
Plotting recipes for geo arrays with XYZ dimensions

### DIFF
--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,3 +1,7 @@
+abstract type GeoXDim{T,Mo,Me} <: XDim{T,Mo,Me} end
+abstract type GeoYDim{T,Mo,Me} <: YDim{T,Mo,Me} end
+abstract type GeoZDim{T,Mo,Me} <: ZDim{T,Mo,Me} end
+
 """
     Lon <: XDim <: Dimension
     Lon(val=:)
@@ -13,7 +17,7 @@ val = A[Lon(1)]
 mean(A; dims=Lon)
 ```
 """
-@dim Lon XDim "Longitude"
+@dim Lon GeoXDim "Longitude"
 
 """
     Lat <: YDim <: Dimension
@@ -30,7 +34,7 @@ val = A[Lat(1)]
 mean(A; dims=Lat)
 ```
 """
-@dim Lat YDim "Latitude"
+@dim Lat GeoYDim "Latitude"
 
 """
     Vert <: ZDim <: Dimension
@@ -47,7 +51,7 @@ val = A[Vert(1)]
 mean(A; dims=Vert)
 ```
 """
-@dim Vert ZDim "Vertical"
+@dim Vert GeoZDim "Vertical"
 
 """
     Band <: Dimension

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,21 +1,21 @@
 struct GeoPlot end
 
-# We only look at arrays with Lat/Lon here.
+# We only look at arrays with <:GeoXDim/<:GeoYDim here.
 # Otherwise they fall back to DimensionalData.jl recipes
 @recipe function f(A::AbstractGeoArray)
     A = GeoArray(A)
-    if all(hasdim(A, (Lat(), Lon())))
+    if all(hasdim(A, (GeoXDim, GeoYDim)))
         # Heatmap or multiple heatmaps. Use GD recipes.
         GeoPlot(), prepare(A)
     else
-        # This is not a Lat/Lon heatmap. Fall back to DD recipes after reprojecting
+        # This is not a GeoXDim/GeoYDim heatmap. Fall back to DD recipes after reprojecting
         da = A |> GeoArray |> a -> DimArray(a; dims=_maybe_mapped(dims(a)))
         DimensionalData.DimensionalPlot(), da
     end
 end
 
 # Plot 3d arrays as multiple tiled plots
-@recipe function f(::GeoPlot, A::GeoArray{T,3,<:Tuple{<:Lat,<:Lon,D}}) where {T,D}
+@recipe function f(::GeoPlot, A::GeoArray{T,3,<:Tuple{<:GeoXDim,<:GeoYDim,D}}) where {T,D}
     nplots = size(A, 3)
     if nplots > 1
         :layout --> nplots
@@ -35,13 +35,13 @@ end
     end
 end
 
-# # Permute for correct Lat/Lon order
-@recipe function f(::GeoPlot, A::GeoArray{T,3}) where {T}
-    GeoPlot(), permutedims(A, (Lat, Lon, Dimension))
+# # Permute for correct order
+@recipe function f(::GeoPlot, A::GeoArray{T,3}) where T
+    GeoPlot(), permutedims(A, (GeoXDim, GeoYDim, Dimension))
 end
 
 # # Plot a sinlge 2d map
-@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:Lat,<:Lon}}) where T
+@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:GeoXDim,<:GeoYDim}}) where T
     :seriestype --> :heatmap
     :aspect_ratio --> 1
     :colorbar_title --> name(A)
@@ -50,8 +50,8 @@ end
     lons, lats, parent(A)
 end
 
-# # Permute for correct Lat/Lon order
-@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:Lon,<:Lat}}) where T
+# # Permute for correct order
+@recipe function f(::GeoPlot, A::GeoArray{T,2,<:Tuple{<:GeoXDim,<:GeoYDim}}) where T
     GeoPlot(), permutedims(A)
 end
 

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -62,6 +62,8 @@ end
         clims = (A_min, A_max)
     end
 
+    clims = get(plotattributes, :clims, clims)
+
     if get(plotattributes, :seriestype, :none) == :contourf
         :linewidth --> 0
         :levels --> range(clims[1], clims[2], length=20)
@@ -94,7 +96,12 @@ end
     :colorbar_title --> array_name
 
     x1, x2 = map(prepare, dims(A))
-    x1, x2, parent(A)
+
+    if get(plotattributes, :seriestype, :none) == :contourf
+        x1, x2, clamp.(A, clims[1], clims[2])
+    else
+        x1, x2, parent(A)
+    end
 end
 
 # # Plot a vertical 1d line

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -47,11 +47,31 @@ end
         :seriescolor --> :balance
         :clims --> (-A_limit, A_limit)
     end
+
+    dim1 = dims(A, 1)
+    dim2 = dims(A, 2)
+
+    xguide = name(dim1) |> string
+    yguide = name(dim2) |> string
+    colorbar_title = name(A) |> string
+
+    if haskey(dim1.metadata, :units)
+        xguide *= " ($(dim1.metadata[:units]))"
+    end
+
+    if haskey(dim2.metadata, :units)
+        yguide *= " ($(dim2.metadata[:units]))"
+    end
+
+    if haskey(A.metadata, :units)
+        colorbar_title *= " ($(A.metadata[:units]))"
+    end
+
     :seriestype --> :heatmap
-    :colorbar_title --> name(A)
     :title --> DD._refdims_title(A)
-    :xguide --> name(dims(A, 1))
-    :yguide --> name(dims(A, 2))
+    :xguide --> xguide
+    :yguide --> yguide
+    :colorbar_title --> colorbar_title
     x1, x2 = map(prepare, dims(A))
     x1, x2, permutedims(A) |> parent
 end

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -85,7 +85,7 @@ end
     end
 
     if haskey(A.metadata, :units)
-        colorbar_title *= " ($(A.metadata[:units]))"
+        colorbar_title = array_name * " ($(A.metadata[:units]))"
     end
 
     :seriestype --> :heatmap
@@ -109,7 +109,7 @@ end
     z_dim = dims(A, 1)
     yguide = name(z_dim) |> string
     if haskey(z_dim.metadata, :units)
-        yguide *= " ($(dim1.metadata[:units]))"
+        yguide *= " ($(z_dim.metadata[:units]))"
     end
 
     xguide = name(A) |> string


### PR DESCRIPTION
This might be a controversial PR since it modifies the plotting recipes quite a bit, especially with a focus on plotting geo arrays with XYZ dimensions.

Happy to work on this PR to get something that works nicely for both Lat/Lon and XYZ plots.

This PR also introduces `GeoXDim`, `GeoYDim`, and `GeoZDim` for `Lat`/`Lon` to subtype following @rafaqz's suggestion in #103.

Resolves #103

Some examples to showcase the motivation behind my changes (and this PR):

# xy plot

```
GeoArray with dimensions:
 x (type xC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
 y (type yC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
 z (type zC): 1260.0 (Sampled: Ordered Regular Intervals)
```

![image](https://user-images.githubusercontent.com/20099589/100175719-ecf22480-2e9c-11eb-8ce7-b1592a5ea8f8.png)

# yz plot

```
GeoArray with dimensions:
 y (type yC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
 z (type zC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
 x (type xC): 620.0 (Sampled: Ordered Regular Intervals)

```

![image](https://user-images.githubusercontent.com/20099589/100175816-1e6af000-2e9d-11eb-9fad-d920de6a32f5.png)

# xz plot

```
GeoArray with dimensions:
 x (type xC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
 z (type zC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
 y (type yC): 2540.0 (Sampled: Ordered Regular Intervals)
```

![image](https://user-images.githubusercontent.com/20099589/100175912-49554400-2e9d-11eb-8a19-41e905f9c721.png)

# Vertical profiles

```
GeoArray with dimensions:
 z (type zC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
 x (type xC): 620.0 (Sampled: Ordered Regular Intervals)
 y (type yC): 1780.0 (Sampled: Ordered Regular Intervals)
```

![image](https://user-images.githubusercontent.com/20099589/100176073-a18c4600-2e9d-11eb-9beb-7111ef524816.png)

# Stacked plots

```
GeoArray with dimensions:
 x (type xC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
 y (type yC): Float64[20.0, 60.0, …, 1220.0, 1260.0] (Sampled: Ordered Regular Intervals) (length 32) 
 z (type zC): Float64[20.0, 340.0, …, 1940.0, 2260.0] (Sampled: Ordered Regular Intervals) (length 8) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
```

![image](https://user-images.githubusercontent.com/20099589/100176250-f203a380-2e9d-11eb-9be1-2ff065779394.png)

