### PR TITLE
Print the length of each GeoArray dimension

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -8,7 +8,7 @@ Base.show(io::IO, A::AbstractGeoArray) = begin
     end
     print(io, " with dimensions:\n")
     for d in dims(A)
-        print(io, " ", d, "\n")
+        print(io, " ", d, " (length ", length(d), ") \n")
     end
     if !isempty(refdims(A))
         print(io, "and referenced dimensions:\n")


### PR DESCRIPTION
`Base.show` for `GeoArray` looks like this now:

```
GeoArray with dimensions:
 x (type xC): Float64[20.0, 60.0, …, 2500.0, 2540.0] (Sampled: Ordered Regular Intervals) (length 64) 
 y (type yC): Float64[20.0, 60.0, …, 1220.0, 1260.0] (Sampled: Ordered Regular Intervals) (length 32) 
 z (type zC): Float64[20.0, 340.0, …, 1940.0, 2260.0] (Sampled: Ordered Regular Intervals) (length 8) 
and referenced dimensions:
 Time (type Ti): 7330.000000067156 (Sampled: Ordered Irregular Intervals)
```

Resolves https://github.com/rafaqz/DimensionalData.jl/issues/206 I guess