### PR TITLE
stack keys are a keyword argument

### DIFF
--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -173,10 +173,10 @@ end
 
 
 """
+    NCDstack(filename::String; refdims=(), window=(), metadata=nothing, childkwargs=())
     NCDstack(filenames; keys, kw...)
     NCDstack(filenames...; keys, kw...)
-    NCDstack(files::NamedTuple; refdims=(), window=(), metadata=nothing, childkwargs=())
-    NCDstack(filename::String; refdims=(), window=(), metadata=nothing, childkwargs=())
+    NCDstack(filenames::NamedTuple; refdims=(), window=(), metadata=nothing, childkwargs=())
 
 A lazy [`AbstractGeoStack`](@ref) that uses NCDatasets.jl to load NetCDF files.
 Can load a single multi-layer netcdf file, or multiple single-layer netcdf
@@ -228,21 +228,12 @@ function NCDstack(filename::AbstractString;
 )
     NCDstack(filename, refdims, window, metadata, childkwargs)
 end
-# These actually return a GeoStack
-NCDstack(filenames...; kw...) = NCDstack(filenames; kw...)
-function NCDstack(filenames::Union{Tuple{AbstractString,Vararg},Vector{AbstractString}},
-    keys=_ncfilenamekeys(filenames); kw...)
-    NCDstack(NamedTuple{keys}(filenames); kw...)
+# These actually return a DiskStack
+NCDstack(filenames::AbstractString...; kw...) = NCDstack(filenames; kw...)
+function NCDstack(filenames; keys=_ncfilenamekeys(filenames), kw...)
+    DiskStack(filenames; keys=keys, childtype=NCDarray, kw...)
 end
-function NCDstack(files::NamedTuple;
-    refdims=(),
-    window=(),
-    metadata=nothing,
-    childkwargs=()
-)
-    GeoStack(NamedTuple{keys}(filenames), refdims, window, metadata,
-             childtype=NCDarray, childkwargs)
-end
+NCDstack(filenames::NamedTuple; kw...) = DiskStack(filenames; childtype=NCDarray, kw...)
 
 childtype(::NCDstack) = NCDarray
 childkwargs(stack::NCDstack) = stack.childkwargs

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -20,10 +20,6 @@ getindex applied to all the arrays in the stack.
 """
 abstract type AbstractGeoStack{T} end
 
-function (::Type{T})(data, keys; kwargs...) where T<:AbstractGeoStack
-    T(NamedTuple{Tuple(Symbol.(keys))}(Tuple(data)); kwargs...)
-end
-
 # Standard fields
 
 DD.refdims(s::AbstractGeoStack) = s.refdims
@@ -353,7 +349,6 @@ Base.convert(::Type{GeoStack}, src::AbstractGeoStack) = GeoStack(src)
 
 
 # Concrete DiskGeoStack implementation ######################################################
-
 """
     DiskStack(filenames...; keys, kw...)
     DiskStack(filenames; keys, kw...)
@@ -396,7 +391,7 @@ end
 function DiskStack(filenames; keys, kw...)
     DiskStack(NamedTuple{cleankeys(keys)}((filenames...,)); kw...)
 end
-DiskStack(filenames...; kw...) = DiskStack(filenames; kw...)
+DiskStack(filenames::AbstractString...; kw...) = DiskStack(filenames; kw...)
 
 # Other base methods
 


### PR DESCRIPTION
`keys` could be keyword or arg, but only keyword is used anywhere, and key as a second argument could cause bugs with slurped methods.

This PR removes key as second argument methods.