### PR TITLE
names is now keys in HDF5

### DIFF
--- a/src/sources/smap.jl
+++ b/src/sources/smap.jl
@@ -127,7 +127,7 @@ end
 # HDF5 uses `names` instead of `keys` so we have to special-case it
 function Base.keys(stack::SMAPstack)
     _smapread(filename(stack)) do dataset
-        cleankeys(names(dataset[SMAPGEODATA]))
+        cleankeys(keys(dataset[SMAPGEODATA]))
     end
 end
 


### PR DESCRIPTION
One line change - HDF5.jl seems to have dropped `names` and just has `keys`. So we use `keys` for SMAP.