### PR TITLE
fix ncdatasets new bounds method clash

### DIFF
--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -1,4 +1,5 @@
-using ArchGDAL, GeoData, Test, Statistics, Dates, Plots, NCDatasets
+using GeoData, Test, Statistics, Dates, Plots
+import ArchGDAL, NCDatasets
 using GeoData: window, mode, span, sampling, name
 
 include(joinpath(dirname(pathof(GeoData)), "../test/test_utils.jl"))
@@ -7,7 +8,6 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
 
 @testset "GDALarray" begin
     gdalarray = GDALarray(path; mappedcrs=EPSG(4326), name=:test);
-    metadata(dims(gdalarray))
 
     @testset "open" begin
         @test open(A -> A[Lat=1], gdalarray) == gdalarray[:, 1, :]

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -1,4 +1,5 @@
-using GeoData, Test, Statistics, Dates, Plots, NCDatasets, ArchGDAL
+using GeoData, Test, Statistics, Dates, Plots
+import NCDatasets, ArchGDAL
 using GeoData: name, mode, window, DiskStack
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
@@ -171,7 +172,8 @@ path = joinpath(testpath, "data/rlogo")
     end
 
     @testset "plot" begin
-        p = grdarray |> plot
+        grdarray |> plot
+        grdarray[Band(1)] |> plot
     end
 
 end
@@ -246,11 +248,11 @@ end
 
 @testset "Grd series" begin
     series = GeoSeries([path, path], (Ti,); childtype=GRDarray, childkwargs=(mappedcrs=EPSG(4326), name=:test))
-    @test GeoArray(series[Ti(1)]) == 
+    @test GeoArray(series[Ti(1)]) ==
         GeoArray(GRDarray(path; mappedcrs=EPSG(4326), name=:test))
     stacks = [DiskStack((a=path, b=path); childtype=GRDarray, childkwargs=(mappedcrs=EPSG(4326), name=:test))]
     series = GeoSeries(stacks, (Ti,))
-    @test series[Ti(1)][:a] == 
+    @test series[Ti(1)][:a] ==
         GeoArray(GRDarray(path; mappedcrs=EPSG(4326), name=:test))
     modified_series = modify(Array, series)
     @test typeof(modified_series) <: GeoSeries{<:GeoStack{<:NamedTuple{(:a,:b),<:Tuple{<:GeoArray{Float32,3,<:Tuple,<:Tuple,<:Array{Float32,3}},Vararg}}}}

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -1,4 +1,5 @@
-using NCDatasets, ArchGDAL, GeoData, Test, Statistics, Dates, CFTime, Plots, GeoFormatTypes
+using GeoData, Test, Statistics, Dates, CFTime, Plots, GeoFormatTypes
+import ArchGDAL, NCDatasets
 using GeoData: name, window, mode, span, sampling, val, Ordered
 include(joinpath(dirname(pathof(GeoData)), "../test/test_utils.jl"))
 
@@ -173,7 +174,7 @@ stackkeys = (
     end
 
     @testset "plot" begin
-        ncarray |> plot
+        ncarray[Ti(1:3:12)] |> plot
         ncarray[Ti(1)] |> plot
         ncarray[Lat(100), Ti(1)] |> plot
     end

--- a/test/sources/smap.jl
+++ b/test/sources/smap.jl
@@ -1,4 +1,5 @@
-using HDF5, GeoData, Test, Statistics, Dates
+using GeoData, Test, Statistics, Dates
+import ArchGDAL, NCDatasets, HDF5
 using GeoData: Time, window, name
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))


### PR DESCRIPTION
a minor bump in NCDatasets broke tests here by introducing the `bounds` method.