### PR TITLE
reformat docs and apply strict=true to build

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,7 @@ using Documenter, GeoData, HDF5, ArchGDAL, NCDatasets
 makedocs(
     modules = [GeoData],
     sitename = "GeoData.jl",
+    strict = true,
 )
 
 deploydocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,12 +7,21 @@ GeoData
 ## Dimensions
 
 ```@docs
+GeoData.GeoXDim
+GeoData.GeoYDim
+GeoData.GeoZDim
 Lat
 Lon
 Vert
 Band
+```
+
+## Index modes
+
+```@docs
+GeoData.AbstractProjected
 Projected
-Converted
+Mapped
 ```
 
 ## Array
@@ -22,7 +31,7 @@ AbstractGeoArray
 MemGeoArray
 DiskGeoArray
 GeoArray
-Open
+GeoData.OpenGeoArray
 ```
 
 ## Stack
@@ -44,15 +53,6 @@ GeoSeries
 SMAPseries
 ```
 
-## Metadata
-
-```@docs
-Metadata
-DimMetadata
-ArrayMetadata
-StackMetadata
-```
-
 # Sources
 
 ## GRD
@@ -60,7 +60,7 @@ StackMetadata
 R GRD files can be loaded natively. The are always 3 dimensional, and have
 [`Lat`](@ref), [`Lon`](@ref) and [`Band`](@ref) dimensions.
 
-If ArchGDAL.jl is loaded, they can have [`usercrs`](@ref) and be 
+If ArchGDAL.jl is loaded (to enable reprojection), they can have [`mappedcrs`](@ref).
 
 ```@docs
 GRDarray
@@ -74,7 +74,7 @@ GRDarrayMetadata
 NetCDF files required NCDatasets.jl:
 
 ```julia
-using NCDatasets
+import NCDatasets
 ```
 
 Single files can be treated as a array or a stack of arrays. 
@@ -93,7 +93,7 @@ GDAL requires [ArchGDAL.jl](https://github.com/yeesian/ArchGDAL.jl/issues) to be
 available: 
 
 ```julia
-using ArchGDAL
+import ArchGDAL
 ```
 
 ```@docs
@@ -111,7 +111,7 @@ global layers of soil moisture, temperature and other related data.
 It uses a custom format of HDF5 files, so required HDF5.jl to be available:
 
 ```julia
-using HDF5
+import HDF5
 ```
 
 Files must be downloaded manually due to authentication restrictions. As the
@@ -134,20 +134,16 @@ GeoData.jl is a direct extension of DimensionalData.jl.
 These methods are specific to GeoData.jl:
 
 ```@docs
-write
-cat
-copy!
 replace_missing
+resample
 boolmask
 missingmask
-convertmode
-reproject
 aggregate
 aggregate!
 disaggregate
 disaggregate!
-GeoData.alloc_ag
-GeoData.alloc_disag
+convertmode
+reproject
 ```
 
 Field access:
@@ -155,11 +151,24 @@ Field access:
 ```@docs
 missingval
 crs
-usercrs
-dimcrs
+mappedcrs
 mappedbounds
-mappedval
-GeoData.filename
+mappedindex
+data
 ```
 
+Not exported:
+```@docs
+GeoData.filename
+GeoData.childkwargs
+```
 
+These Base and DimensionalData methods have specific GeoData.jl version:
+
+```@docs
+open
+write
+cat
+copy!
+modify
+```

--- a/src/aggregate.jl
+++ b/src/aggregate.jl
@@ -248,11 +248,7 @@ function disaggregate!(loci::Tuple{Locus,Vararg}, dst::AbstractDimArray, src, sc
     return dst
 end
 
-"""
-    alloc_ag(method, A::AbstractDimArray, scale)
-
-Allocate an array of the correct size to aggregate `A` by `scale`
-"""
+# Allocate an array of the correct size to aggregate `A` by `scale`
 alloc_ag(method, A::AbstractDimArray, scale) = alloc_ag((method,), A, scale)
 function alloc_ag(method::Tuple, A::AbstractDimArray, scale)
     intscale = _scale2int(dims(A), scale)
@@ -263,11 +259,7 @@ function alloc_ag(method::Tuple, A::AbstractDimArray, scale)
     return rebuild(A; data=data_, dims=dims_)
 end
 
-"""
-    alloc_disag(method, A::AbstractDimArray, scale)
-
-Allocate an array of the correct size to disaggregate `A` by `scale`
-"""
+# Allocate an array of the correct size to disaggregate `A` by `scale`
 alloc_disag(method, A::AbstractDimArray, scale) = alloc_disag((method,), A, scale)
 function alloc_disag(method::Tuple, A::AbstractDimArray, scale)
     intscale = _scale2int(dims(A), scale)
@@ -278,19 +270,11 @@ function alloc_disag(method::Tuple, A::AbstractDimArray, scale)
 end
 
 
-"""
-    upsample(index::Int, scale::Int)
-
-Convert indicies from the aggregated array to the larger original array.
-"""
+# Convert indicies from the aggregated array to the larger original array.
 upsample(index::Int, scale::Int) = (index - 1) * scale + 1
 upsample(index::Int, scale::Colon) = index
 
-"""
-    downsample(index::Int, scale::Int)
-
-Convert indicies from the original array to the aggregated array.
-"""
+# Convert indicies from the original array to the aggregated array.
 downsample(index::Int, scale::Int) = (index - 1) ÷ scale + 1
 downsample(index::Int, scale::Colon) = index
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,8 +1,10 @@
 
 """
-`AbstractGeoArray` wraps an array (or location of an array) and metadata
-about its contents. It may be memory ([`GeoArray`](@ref)) or disk-backed
-([`NCDarray`](@ref), [`GDALarray`](@ref), [`GRDarray`](@ref)).
+    AbstractGeoArray <: DimensionalData.AbstractDimArray
+
+Abstract supertype for objects that wrap an array (or location of an array) 
+and metadata about its contents. It may be memory ([`GeoArray`](@ref)) or
+disk-backed ([`NCDarray`](@ref), [`GDALarray`](@ref), [`GRDarray`](@ref)).
 
 `AbstractGeoArray`s inherit from [`AbstractDimArray`]($DDarraydocs)
 from DimensionalData.jl. They can be indexed as regular Julia arrays or with
@@ -104,11 +106,13 @@ Abstract supertype for all memory-backed GeoArrays where the data is an array.
 abstract type MemGeoArray{T,N,D,A} <: AbstractGeoArray{T,N,D,A} end
 
 """
+    DiskGeoArray <: AbstractGeoArray
+
 Abstract supertype for all disk-backed GeoArrays.
 For these the data is lazyily loaded from disk.
 
 To load a `DiskGeoArray` and operate on the data multiple times, use
-[`Open`](@ref) and a `do` block.
+[`open`](@ref) and a `do` block.
 """
 abstract type DiskGeoArray{T,N,D,A} <: AbstractGeoArray{T,N,D,A} end
 
@@ -169,33 +173,25 @@ Base.write(filename::AbstractString, A::T) where T <: DiskGeoArray = write(filen
 # Concrete implementation ######################################################
 
 """
-    GeoArray(A::AbstractArray{T,N}, dims::Tuple;
-             refdims=(), name=Symbol(""), metadata=NoMetadata(), missingval=missing)
-    GeoArray(A::AbstractArray{T,N};
-             dims, refdims=(), name=Symbol(""), metadata=NoMetadata(), missingval=missing)
-    GeoArray(A::AbstractGeoArray; [data=data(A), dims=dims(A), refdims=refdims(A),
-             name=name(A), metadata=metadata(A), missingval=missingval(A)]) =
+    GeoArray <: MemGeoArray
+
+    GeoArray(A::AbstractArray{T,N}, dims::Tuple; kw...)
+    GeoArray(A::AbstractArray{T,N}; dims, kw...)
+    GeoArray(A::AbstractGeoArray; kw...) =
 
 A generic, memory-backed spatial array type. All [`AbstractGeoArray`](@ref) are
 converted to `GeoArray` when indexed or otherwise transformed.
 
-# Keyword Arguments
+# Keywords
 
-- `name`: `Symbol` name for the array.
+- `data`: can replace the data in an `AbstractGeoArray`
 - `dims`: `Tuple` of `Dimension`s for the array.
 - `refdims`: `Tuple of` position `Dimension`s the array was sliced from,
-  defaulting to `()`.
+    defaulting to `()`.
+- `name`: `Symbol` name for the array.
 - `missingval`: Value reprsenting missing values, defaulting to `missing`.
-  can be passed it.
-- `metadata`: [`Metadata`](@ref) object for the array, or `NoMetadata()`.
-
-## Example
-
-```julia
-A = GRDarray(gdalarray; name="surfacetemp")
-# Select Australia using lat/lon coords, whatever the crs is underneath.
-A[Lat(Between(-10, -43), Lon(Between(113, 153)))
-```
+    can be passed it.
+- `metadata`: `ArrayMetadata` object for the array, or `NoMetadata()`.
 """
 struct GeoArray{T,N,D<:Tuple,R<:Tuple,A<:AbstractArray{T,N},Na,Me,Mi} <: MemGeoArray{T,N,D,A}
     data::A

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,14 +1,33 @@
+"""
+    GeoXDim <: Dimension.XDim
+
+Abstract supertype for GeoSpatial X dimensions. 
+"""
 abstract type GeoXDim{T,Mo,Me} <: XDim{T,Mo,Me} end
+
+"""
+    GeoXDim <: Dimension.XDim
+
+Abstract supertype for GeoSpatial Y dimensions. 
+"""
 abstract type GeoYDim{T,Mo,Me} <: YDim{T,Mo,Me} end
+
+"""
+    GeoZDim <: Dimension.ZDim
+
+Abstract supertype for GeoSpatial Z dimensions. 
+"""
 abstract type GeoZDim{T,Mo,Me} <: ZDim{T,Mo,Me} end
 
 """
-    Lon <: XDim <: Dimension
+    Lon <: GeoXDim
+
     Lon(val=:)
 
 Longitude [`Dimension`]($DDdimdocs).
 
 ## Example:
+
 ```julia
 longdim = Lon(10:10:100)
 # Or
@@ -20,12 +39,14 @@ mean(A; dims=Lon)
 @dim Lon GeoXDim "Longitude"
 
 """
-    Lat <: YDim <: Dimension
+    Lat <: GeoYDim
+
     Lat(val=:)
 
 Latitude [`Dimension`]($DDdimdocs).
 
 ## Example:
+
 ```julia
 vertdim = Lat(10:10:100)
 # Or
@@ -37,12 +58,14 @@ mean(A; dims=Lat)
 @dim Lat GeoYDim "Latitude"
 
 """
-    Vert <: ZDim <: Dimension
+    Vert <: GeoZDim
+
     Vert(val=:)
 
 Vertical [`Dimension`]($DDdimdocs).
 
 ## Example:
+
 ```julia
 vertdim = Vert(10:10:100)
 # Or
@@ -55,6 +78,7 @@ mean(A; dims=Vert)
 
 """
     Band <: Dimension
+
     Band(val=:)
 
 Band [`Dimension`]($DDdimdocs) for multi-band rasters.
@@ -75,7 +99,7 @@ mean(A; dims=Band)
 """
     mappedbounds(x)
 
-Get the bounds converted to the `usercrs` value.
+Get the bounds converted to the [`mappedcrs`](@ref) value.
 
 Whithout ArchGDAL loaded, this is just the regular bounds.
 """
@@ -108,7 +132,7 @@ projectedbounds(::Projected, dim) = bounds(dim)
 """
     mappedindex(x)
 
-Get the index value of a dimension converted to the `usercrs` value.
+Get the index value of a dimension converted to the `mappedcrs` value.
 
 Whithout ArchGDAL loaded, this is just the regular dim value.
 """
@@ -135,4 +159,5 @@ projectedindex(::Projected, dim) = index(dim)
     else
         error("cannot get projected index of a $(nameof(typeof(mode))) mode dim")
     end
+
 

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -1,9 +1,16 @@
+"""
+    AbstractProjected <: AbstractSampled
+
+Abstract supertype for projected index modes.
+"""
 abstract type AbstractProjected{O,Sp,Sa} <: AbstractSampled{O,Sp,Sa} end
 
 # For now we just remove CRS on GPU - it often contains strings
 Adapt.adapt_structure(to, m::AbstractProjected) = Sampled(order(m), span(m), sampling(m))
 
 """
+    Projected <: AbstractProjected
+
     Projected(order::Order, span, sampling, crs, mappedcrs)
     Projected(; order=Ordered(), span=AutoSpan(), sampling=Points(), crs, mappedcrs=nothing)
 
@@ -53,6 +60,8 @@ function DD.rebuild(
 end
 
 """
+    Mapped <: AbstractProjected
+
     Mapped(order::Order, span, sampling, crs, mappedcrs)
     Mapped(; order=Ordered(), span=AutoSpan(), sampling=Points(), crs=nothing, mappedcrs)
 

--- a/src/open.jl
+++ b/src/open.jl
@@ -1,5 +1,9 @@
 
-# Used internally to expose open disk files inside a `do` block
+"""
+    OpenGeoArray <: AbstractGeoArray
+
+Used internally to expose open disk files inside a `do` block
+"""
 struct OpenGeoArray{T,N,D<:Tuple,R<:Tuple,A,Na<:Symbol,Me,Mi} <: AbstractGeoArray{T,N,D,A}
     data::A
     dims::D

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -7,19 +7,21 @@ export resample
 
 `resample` uses `ArchGDAL.gdalwarp` to resample an `AbstractGeoArray`.
 
-## Arguments
+# Arguments
+
 - `A`: The `AbstractGeoArray` to resample.
 - `resolution`: A `Number` specifying the resolution for the output.
-  If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
+    If the keyword argument `crs` (described below) is specified, `resolution` must be in units of the `crs`.
 - `snap`: an `AbstractGeoArray` whos resolution, crs and bounds will be snapped to.
-  For best results it should roughly cover the same extent, or a subset of `A`.
+    For best results it should roughly cover the same extent, or a subset of `A`.
 
-## Keyword Arguments
+# Keywords
+
 - `crs`: A `GeoFormatTypes.GeoFormat` specifying an output crs
-  (`A` with be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
+    (`A` with be reprojected to `crs` in addition to being resampled). Defaults to `crs(A)`
 - `method`: A `String` specifying the method to use for resampling. Defaults to `"near"`
-  (nearest neighbor resampling). See [resampling method](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r)
-  in the gdalwarp docs for a complete list of possible values.
+    (nearest neighbor resampling). See [resampling method](https://gdal.org/programs/gdalwarp.html#cmdoption-gdalwarp-r)
+    in the gdalwarp docs for a complete list of possible values.
 
 """
 function resample end

--- a/src/series.jl
+++ b/src/series.jl
@@ -1,5 +1,7 @@
 """
-`AbstractGeoSeries` are a high-level `DimensionalArray` that hold stacks, arrays,
+    AbstractGeoSeries <: DimensionalData.AbstractDimensionalArray
+
+Abstract supertype for high-level `DimensionalArray` that hold stacks, arrays,
 or the paths they can be loaded from. `GeoSeries` are indexed with dimensions
 as with a `AbstractGeoArray`. This is useful when you have multiple files containing
 rasters or stacks of rasters spread over dimensions like time and elevation.
@@ -71,12 +73,20 @@ end
 
 
 """
-    GeoSeries(data::Array{T}, dims; refdims=(), childtype=DD.basetypeof(T),
-              childkwargs=()) where T<:Union{<:AbstractGeoStack,<:AbstractGeoArray}
-    GeoSeries(data, dims; refdims=(), childtype, childkwargs)
+    GeoSeries <: AbstractGeoSeries
+
+    GeoSeries(A::AbstractArray{<:AbstractGeoArray}, dims; kw...)
+    GeoSeries(A::AbstractArray{<:AbstractGeoStack}, dims; kw...)
+    GeoSeries(filenames::AbstractArray{<:AbstractString}, dims; kw...)
 
 Concrete implementation of [`AbstractGeoSeries`](@ref).
 Series hold paths to array or stack files, along some dimension(s).
+
+# Keywords
+
+- `refdims`: existing reference 
+- `childtype`: type of child objects - an `AbstractGeoSeries` or `AbstractGeoStack`
+- `childkwargs`: keyword arguments passed to the child object on construction.
 """
 struct GeoSeries{T,N,D,R,A<:AbstractArray{T,N},C,K} <: AbstractGeoSeries{T,N,D,A,C}
     data::A

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -25,6 +25,8 @@ const REV_GRD_DATATYPE_TRANSLATION =
 # Metadata ########################################################################
 
 """
+    GRDdimMetadata <: AbstractDimMetadata
+
     GRDdimMetadata(val::Union{Dict,NamedTuple})
     GRDdimMetadata(pairs::Pair...) => GRDdimMetadata{Dict}
     GRDdimMetadata(; kw...) => GRDdimMetadata{NamedTuple}
@@ -36,6 +38,8 @@ struct GRDdimMetadata{T} <: AbstractDimMetadata{T}
 end
 
 """
+    GRDarrayMetadata <: AbstractArrayMetadata
+
     GRDarrayMetadata(val::Union{Dict,NamedTuple})
     GRDarrayMetadata(pairs::Pair...) => GRDarrayMetadata{Dict}
     GRDarrayMetadata(; kw...) => GRDarrayMetadata{NamedTuple}
@@ -138,13 +142,9 @@ Base.Array(grd::GRDattrib) = _mmapgrd(Array, grd)
 # Array ########################################################################
 
 """
-    GRDarray(filename::String;
-        mappedcrs=nothing,
-        dims=(),
-        refdims=(),
-        name=nothing,
-        missingval=nothing,
-        metadata=nothing)
+    GRDarray <: DiskGeoArray
+
+    GRDarray(filename::String; kw...)
 
 A [`DiskGeoArray`](@ref) that loads .grd files lazily from disk.
 
@@ -155,17 +155,17 @@ A [`DiskGeoArray`](@ref) that loads .grd files lazily from disk.
 
 - `filename`: `String` pointing to a grd file. Extension is optional.
 
-## Keyword Arguments
+## Keywords
 
 - `mappedcrs`: CRS format like `EPSG(4326)` used in `Selectors` like `Between` and `At`, and
-  for plotting. Can be any CRS `GeoFormat` from GeoFormatTypes.jl, like `WellKnownText`.
+    for plotting. Can be any CRS `GeoFormat` from GeoFormatTypes.jl, like `WellKnownText`.
 - `name`: `String` name for the array, taken from the files `layername` attribute unless passed in.
 - `dims`: `Tuple` of `Dimension`s for the array. Detected automatically, but can be passed in.
 - `refdims`: `Tuple of` position `Dimension`s the array was sliced from.
 - `missingval`: Value reprsenting missing values. Detected automatically when possible, but
-  can be passed it.
-- `metadata`: [`Metadata`](@ref) object for the array. Detected automatically as
-  [`GRDarrayMetadata`](@ref), but can be passed in.
+    can be passed it.
+- `metadata`: `Metadata` object for the array. Detected automatically as
+    [`GRDarrayMetadata`](@ref), but can be passed in.
 
 ## Example
 
@@ -284,13 +284,9 @@ end
 # AbstractGeoStack methods
 
 """
-    GRDstack(filenames; keys, kw...)
-    GRDstack(filenames...; keys, kw...)
-    GRDstack(filenames::NamedTuple;
-             window=(),
-             metadata=nothing,
-             childkwargs=(),
-             refdims=())
+    GRDstack(filenames; keys, kw...) => DiskStack
+    GRDstack(filenames...; keys, kw...) => DiskStack
+    GRDstack(filenames::NamedTuple; kw...) => DiskStack
 
 Convenience method to create a DiskStack of [`GRDarray`](@ref) from `filenames`.
 
@@ -299,12 +295,12 @@ Convenience method to create a DiskStack of [`GRDarray`](@ref) from `filenames`.
 - `filenames`: A NamedTuple of stack keys and `String` filenames, or a `Tuple`,
   `Vector` or splatted arguments of `String` filenames.
 
-## Keyword arguments
+## Keywords
 
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
-  contained arrays when they are accessed.
-- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+    contained arrays when they are accessed.
+- `metadata`: Metadata as a `StackMetadata` object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -4,6 +4,8 @@ const NCD = NCDatasets
 export NCDarray, NCDstack, NCDdimMetadata, NCDarrayMetadata, NCDstackMetadata
 
 """
+    NCDdimMetadata <: AbstractDimMetadata
+
     NCDdimMetadata(val::Union{Dict,NamedTuple})
     NCDdimMetadata(pairs::Pair...) => NCDdimMetadata{Dict}
     NCDdimMetadata(; kw...) => NCDdimMetadata{NamedTuple}
@@ -15,6 +17,8 @@ struct NCDdimMetadata{T} <: AbstractDimMetadata{T}
 end
 
 """
+    NCDarrayMetadata <: AbstractArrayMetadata
+
     NCDarrayMetadata(val::Union{Dict,NamedTuple})
     NCDarrayMetadata(pairs::Pair...) => NCDarrayMetadata{Dict}
     NCDarrayMetadata(; kw...) => NCDarrayMetadata{NamedTuple}
@@ -26,6 +30,8 @@ struct NCDarrayMetadata{T} <: AbstractArrayMetadata{T}
 end
 
 """
+    NCDstackMetadata <: AbstractStackMetadata
+
     NCDstackMetadata(val::Union{Dict,NamedTuple})
     NCDstackMetadata(pairs::Pair...) => NCDstackMetadata{Dict}
     NCDstackMetadata(; kw...) => NCDstackMetadata{NamedTuple}
@@ -59,6 +65,8 @@ const DIMMAP = Dict("lat" => Lat,
 
 # Array ########################################################################
 """
+    NCDarray <: DiskGeoArray
+
     NCDarray(filename::AbstractString; name=nothing, refdims=(),
              dims=nothing, metadata=nothing, crs=nothing, mappedcrs=EPSG(4326))
 
@@ -90,7 +98,7 @@ future, including detecting and converting the native NetCDF projection format.
 - `refdims`: `Tuple of` position `Dimension`s the array was sliced from.
 - `missingval`: Value reprsenting missing values. Detected automatically when possible, but
   can be passed it.
-- `metadata`: [`Metadata`](@ref) object for the array. Detected automatically as
+- `metadata`: `Metadata` object for the array. Detected automatically as
   [`NCDarrayMetadata`](@ref), but can be passed in.
 
 ## Example
@@ -173,6 +181,8 @@ end
 
 
 """
+    NCDstack <: DiskGeoStack
+
     NCDstack(filename::String; refdims=(), window=(), metadata=nothing, childkwargs=())
     NCDstack(filenames; keys, kw...)
     NCDstack(filenames...; keys, kw...)
@@ -199,7 +209,7 @@ and [`Vert`] or `X`, `Y`, `Z` when detected. Undetected dims use the generic `Di
 - `refdims`: Add dimension position array was sliced from. Mostly used programatically.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
   contained arrays when they are accessed.
-- `metadata`: A [`StackMetadata`](@ref) object.
+- `metadata`: A [`NCDstackMetadata`](@ref) object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the
   [`NCDarray`](@ref) constructor.
 
@@ -259,7 +269,7 @@ Base.keys(s::NCDstack{<:AbstractString}) = cleankeys(_ncread(_nondimkeys, getsou
 
 Write an NCDstack to a single netcdf file, using NCDatasets.jl.
 
-Currently [`DimMetadata`](@ref) is not handled, and [`ArrayMetadata`](@ref)
+Currently `DimMetadata` is not handled, and `ArrayMetadata`
 from other [`AbstractGeoArray`](@ref) @types is ignored.
 """
 function Base.write(filename::AbstractString, ::Type{<:NCDstack}, s::AbstractGeoStack)

--- a/src/sources/smap.jl
+++ b/src/sources/smap.jl
@@ -7,6 +7,8 @@ const SMAPGEODATA = "Geophysical_Data"
 const SMAPCRS = ProjString("+proj=cea +lon_0=0 +lat_ts=30 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0")
 
 """
+    SMAPdimMetadata <: AbstractDimMetadata
+
     SMAPdimMetadata(val::Union{Dict,NamedTuple})
     SMAPdimMetadata(pairs::Pair...) => SMAPdimMetadata{Dict}
     SMAPdimMetadata(; kw...) => SMAPdimMetadata{NamedTuple}
@@ -18,6 +20,8 @@ struct SMAPdimMetadata{T} <: AbstractDimMetadata{T}
 end
 
 """
+    SMAParrayMetadata <: AbstractArrayMetadata
+
     SMAParrayMetadata(val::Union{Dict,NamedTuple})
     SMAParrayMetadata(pairs::Pair...) => SMAParrayMetadata{Dict}
     SMAParrayMetadata(; kw...) => SMAParrayMetadata{NamedTuple}
@@ -29,6 +33,8 @@ struct SMAParrayMetadata{T} <: AbstractArrayMetadata{T}
 end
 
 """
+    SMAPstackMetadata <: AbstractStackMetadata
+
     SMAPstackMetadata(val::Union{Dict,NamedTuple})
     SMAPstackMetadata(pairs::Pair...) => SMAPstackMetadata{Dict}
     SMAPstackMetadata(; kw...) => SMAPstackMetadata{NamedTuple}
@@ -42,29 +48,28 @@ end
 # Stack ########################################################################
 
 """
-    SMAPstack(filename::String;
-              dims=nothing,
-              refdims=nothing,
-              window=())
+    SMAPstacka <: DiskGeoStack
+
+    SMAPstack(filename::String; dims=nothing, refdims=nothing, window=())
 
 `AbstractGeoStack` for [SMAP](https://smap.jpl.nasa.gov/) datasets.
 
 The simplicity of the format means `dims` and `metadata` are the same for all stack layers,
 so we store them as stack fields.
 
-## Arguments
+# Arguments
 
 - `filename`: `String` path to a SMAP .h5 file.
 
-## Keyword arguments
+# Keywords
 
 - `dims`: Dimensions held on the stack as all layers have identical `Dimension`s.
-  These are loaded from the HDF5 by default, but can be passed in to improve performance,
-  as is done by [`SMAPseries`](@ref),
+    These are loaded from the HDF5 by default, but can be passed in to improve performance,
+    as is done by [`SMAPseries`](@ref),
 - `refdims`: As for `dims`. Often the position time `Dimension` from the `SMAPseries`.
 - `metadata`: [`SMAPstackMetadata`](@ref) object. As for `dims`.
 - `window`: Like `view` but lazy, for disk based data. Can be a tuple of Dimensions,
-  selectors or regular indices. These will be applied when the data is loaded or indexed into.
+    selectors or regular indices. These will be applied when the data is loaded or indexed.
 """
 struct SMAPstack{T,D,R,W,M} <: DiskGeoStack{T}
     filename::T
@@ -141,14 +146,14 @@ end
 [`GeoSeries`](@ref) loader for SMAP files and whole folders of files,
 organised along the time dimension. Returns a [`GeoSeries`](@ref).
 
-## Arguments
+# Arguments
 
 - `filenames`: A `String` path to a directory of SMAP files,
-  or a vector of `String` paths to specific files.
+    or a vector of `String` paths to specific files.
 - `dims`: `Tuple` containing `Ti` dimension for the series.
-  Automatically generated form `filenames` unless passed in.
+    Automatically generated form `filenames` unless passed in.
 
-## Keyword Arguments
+# Keywords
 
 - `kw`: Passed to `GeoSeries`.
 """

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -2,7 +2,9 @@
 const Key = Union{Symbol,AbstractString}
 
 """
-`AbstractGeoStack` objects hold multiple [`AbstractGeoArray`](@ref)
+    AbstractGeoStack
+
+Abstract supertype for objects that hold multiple [`AbstractGeoArray`](@ref)
 that share spatial bounds.
 
 They are `NamedTuple`-like structures that may either contain `NamedTuple`
@@ -35,18 +37,6 @@ childkwargs(s::AbstractGeoStack) = s.childkwargs
 
 
 # Interface methods ############################################################
-
-"""
-    getsource(s::AbstractGeoStack, [key])
-
-Get the lower-level child object. This can be an `AbstractGeoArray` or
-another object with GeoData interface methods defined.
-
-Working with the low-level object can be better performance as we do not have to
-processes everything needed to build a full `AbstractGeoArray`.
-"""
-function getsource end
-
 
 """
     modify(f, series::AbstractGeoStack)
@@ -104,12 +94,12 @@ Base.copy!(dst::AbstractArray, src::AbstractGeoStack, key) = copy!(dst, src[key]
 
 Concatenate all or a subset of layers for all passed in stacks.
 
-## Keyword Arguments
+# Keywords
 
 - `keys`: `Tuple` of `Symbol` for the stack keys to concatenate.
 - `dims`: Dimension of child array to concatenate on.
 
-## Example
+# Example
 
 Concatenate the :sea_surface_temp and :humidity layers in the time dimension:
 
@@ -148,7 +138,9 @@ end
 # Memory-based stacks ######################################################
 
 """
-An [`AbstractGeoStack`](@ref) stored in memory.
+    MemGeoStack <: AbstractGeoStack
+
+Abstract supertype for [`AbstractGeoStack`](@ref) stored in memory.
 """
 abstract type MemGeoStack{T} <: AbstractGeoStack{T} end
 
@@ -211,7 +203,9 @@ end
 # Disk-based stacks ######################################################
 
 """
-[`AbstractGeoStack`](@ref)s stored on disk.
+    DiskGeoStack <: AbstractGeoStack
+
+Abstract supertype of [`AbstractGeoStack`](@ref)s stored on disk.
 """
 abstract type DiskGeoStack{T} <: AbstractGeoStack{T} end
 
@@ -298,6 +292,8 @@ end
 # Concrete MemGeoStack implementation ######################################################
 
 """
+    GeoStack <: MemGeoStack
+
     GeoStack(data...; keys, kwargs...)
     GeoStack(data::Union{Vector,Tuple}; keys, kwargs...)
     GeoStack(data::NamedTuple; window=(), metadata=nothing, refdims=(), childkwargs=()) =
@@ -305,18 +301,18 @@ end
 
 A concrete `MemGeoStack` implementation. Holds layers of [`GeoArray`](@ref).
 
-## Argumenst
+# Arguments
 
 - `data`: A `NamedTuple` of [`GeoArray`](@ref), or a `Vector`, `Tuple` or splatted arguments
-  of [`GeoArray`](@ref). The latter options must pass a `keys` keyword argument.
+    of [`GeoArray`](@ref). The latter options must pass a `keys` keyword argument.
 
-## Keyword Argumenst
+# Keywords
 
 - `keys`: Used as stack keys when a `Tuple` or `Vector` or splat of geoarrays are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
-  contained arrays when they are accessed.
+    contained arrays when they are accessed.
 - `refdims`: Reference dimensions from earlier subsetting.
-- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+- `metadata`: Metadata as a `DimensionalData.AbstractStackMetadata` object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 """
@@ -353,25 +349,20 @@ Base.convert(::Type{GeoStack}, src::AbstractGeoStack) = GeoStack(src)
 """
     DiskStack(filenames...; keys, kw...)
     DiskStack(filenames; keys, kw...)
-    DiskStack(filenames::NamedTuple;
-              window=(),
-              metadata=nothing,
-              childtype,
-              childkwargs=()
-              refdims=())
+    DiskStack(filenames::NamedTuple; kw...)
 
 Concrete [`DiskGeoStack`](@ref) implementation. Loads a stack of files lazily from disk.
 
-## Arguments
+# Arguments
 
 - `filename`: a NamedTuple of stack keys and `String` filenames.
 
-## Keyword arguments
+# Keywords
 
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
-  contained arrays when they are accessed.
-- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+    contained arrays when they are accessed.
+- `metadata`: Metadata as a `DimensionalData.StackMetadata` object.
 - `childtype`: The type of the child data. eg. `GDALarray`. Required.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,4 +1,6 @@
-filter_ext(path, ext) = filter(filename -> splitext(filename)[2] == ext, readdir(path))
+filter_ext(path, ext::AbstractString) = filter(fn -> splitext(fn)[2] == ext, readdir(path))
+filter_ext(path, exts::Union{Tuple,AbstractArray}) = 
+    filter(fn -> splitext(fn)[2] in exts, readdir(path))
 
 maybewindow2indices(A, window::Tuple) = maybewindow2indices(A, dims(A), window::Tuple)
 maybewindow2indices(A, dims::Tuple, window::Tuple) =


### PR DESCRIPTION
Cleanup, and error if there are missing or misnamed doc references in future.