### PR TITLE
save GeoArray with GDAL, without crs

### DIFF
--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -118,7 +118,7 @@ end
         driver="GTiff", compress="DEFLATE", tiled=true
     )
 
-Write a [`GDALarray`](@ref) to file, `.tiff` by default, but other GDAL drivers also work.
+Write a [`GDALarray`](@ref) to file, `.tif` by default, but other GDAL drivers also work.
 
 GDAL flags `driver`, `compress` and `tiled` can be passed in as keyword arguments.
 
@@ -345,15 +345,14 @@ function _gdalsetproperties!(dataset, A)
     lat = shiftindexloci(GDAL_LAT_LOCUS, dims(A, Lat))
     lon = convertmode(Projected, lon)
     lat = convertmode(Projected, lat)
-    @assert indexorder(lat) == GDAL_LAT_INDEX
-    @assert indexorder(lon) == GDAL_LON_INDEX
     # Get the geotransform from the updated lat/lon dims
     geotransform = _dims2geotransform(lat, lon)
     # Convert projection to a string of well known text
-    proj = convert(String, convert(WellKnownText, crs(lon)))
-
-    # Write projection, geotransform and data to GDAL
-    AG.setproj!(dataset, proj)
+    if !(crs(lon) isa Nothing)
+        proj = convert(String, convert(WellKnownText, crs(lon)))
+        # Write projection, geotransform and data to GDAL
+        AG.setproj!(dataset, proj)
+    end
     AG.setgeotransform!(dataset, geotransform)
 
     # Set the nodata value. GDAL can't handle missing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,11 +21,11 @@ getmeta(A::AbstractGeoArray, key, fallback) = getmeta(metadata(A), key, fallback
 getmeta(m::Metadata, key, fallback) = get(val(m), key, fallback)
 getmeta(m::NoMetadata, key, fallback) = fallback
 
-# Check that arrayu order amtches expectation
+# Check that array order matches expectation
 checkarrayorder(A, order::Order) = map(d -> checkarrayorder(d, order), dims(A))
 checkarrayorder(A, order::Tuple) = map(checkarrayorder, dims(A), order)
 checkarrayorder(dim::Dimension, order::Order) =
-    arrayorder(dim) == order || @warn "Array order for `$(DD.basetypeof(order))` is `$arrayorder(dim)`, usualy `$order`"
+    arrayorder(dim) == order || @warn "Array order for `$(DD.basetypeof(order))` is `$(arrayorder(dim))`, usualy `$order`"
 
 cleankeys(keys) = Tuple(Symbol.(keys))
 

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -167,6 +167,17 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
             @test all(map((a, b) -> isapprox(a, b; rtol=1e-6), projectedbounds(saved, Lat),  projectedbounds(gdalarray, Lat)))
         end
 
+        @testset "from GeoArray" begin
+            filename = tempname() * ".tiff"
+            ga = GeoArray(rand(100, 200), (Lon, Lat))
+            write(filename, GDALarray, ga)
+            @test parent(GDALarray(filename)[Band(1)]) == parent(ga)
+            filename2 = tempname() * ".tiff"
+            ga2 = GeoArray(rand(100, 200), (Lon(101:200; mode=Sampled()), Lat(1:200; mode=Sampled())))
+            write(filename2, GDALarray, ga2)
+            @test parent(reorder(GDALarray(filename2)[Band(1)], ForwardArray)) == ga2
+       end
+
     end
 
     @testset "show" begin


### PR DESCRIPTION
Allow writing a geoarray with GDAL without `Projected` mode or a crs field. 