### PR TITLE
bugfix map for DiskGeoStack

### DIFF
--- a/src/stack.jl
+++ b/src/stack.jl
@@ -271,6 +271,8 @@ end
 
 @inline Base.view(s::DiskGeoStack, I...) = rebuild(s; window=I)
 
+Base.map(f, s::DiskGeoStack) = GeoStack(s; data=_mapdata(f, s))
+
 
 # Default dims, metadata and missingval methods
 #


### PR DESCRIPTION
Tiny bugfix - `DiskGeoStack` needs to `map` to `GeoStack` as the arrays have been copied to memory to pass to map.