### PR TITLE
add convenience methods geoarray, stack and series

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Data loaded with GeoData.jl has some special properties:
   no matter the order of the index or it's position in the cell.
 - For `Projected` mode `GRDarray` and `GDALarray` You can index in any projection you want to by setting the 
   `mappedcrs` keyword on construction. You don't even need to know the underlying projection, the conversion is 
-  handled automatically. This means Lat/Lon `EPSG(4326)` can be used accross all sources seamlessly if you need that.
+  handled automatically. This means lat/lon `EPSG(4326)` can be used across all sources seamlessly if you need that.
 - Packages building on GeoData.jl can treat `AbstractGeoSeries`, `AbstractGeoStack`, and `AbstrackGeoArray`
   as black boxes:
   - The data could hold tiff or netcdf files, `Array`s in memory or `CuArray`s on the GPU - they
     will all behave in the same way.
   - `AbstractGeoStack` can be a Netcdf or HDF5 file, or a `NamedTuple` of `GDALarray` holding `.tif` files,
-    or all `GeoArray` in memeory, but be treated as if they are all the same thing.
+    or all `GeoArray` in memory, but be treated as if they are all the same thing.
   - Modelling packages do not have to deal with the specifics of spatial file types directly.
   
 
@@ -36,19 +36,19 @@ spatial data can be indexed using named dimensions like `Lat` and `Lon`, `Ti`
 is covered in the [DimensionalData
 docs](https://rafaqz.github.io/DimensionalData.jl/stable/).
 
-GeoData.jl provides general types for holding spatial data: `GeoArray`, `GeoStack`, 
-and `GeoSeries`, and types specific to various backends for loading disk-based data.
-R `.grd` files can be loaded natively using `GRDarray` and `GRDstack`. 
-GDAL files can be loaded with ` GDALarray` and GDALstack when 
-[ArchGDAL.jl](https://github.com/yeesian/ArchGDAL.jl) (v0.5 or higher) is present. 
-NetCDF similarly can be loaded with `NCDarray` and `NCDstack` when
-[NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl) is available.
+GeoData.jl provides general types for holding spatial data: `GeoArray`,
+`GeoStack`, and `GeoSeries`, and types specific to various backends for loading
+disk-based data. All can be loaded using the functions `geoarray`, `stack` and
+`series`, that will guess the backend from the file type. R `.grd` files can be
+loaded natively, GDAL when [ArchGDAL.jl](https://github.com/yeesian/ArchGDAL.jl)
+(v0.5 or higher) is imported, and NetCDF can be loaded when
+[NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl) is imported.
 
-When HDF5.jl is available, files from the Soil Moisture Active Passive
-([SMAP](https://smap.jpl.nasa.gov/)) dataset can be loaded using `SMAPstack`
-or `SMAPseries` to load whole directories. This is both useful for users of
-SMAP, and a demonstration of the potential to build standardised interfaces 
-for custom spatial dataset formats like those used in SMAP.
+When HDF5.jl is imported, files from the Soil Moisture Active Passive
+([SMAP](https://smap.jpl.nasa.gov/)) dataset can be loaded with `stack` or
+`series`. This is both useful for users of SMAP, and a demonstration of the
+potential to build standardised interfaces for custom spatial dataset formats
+like those used in SMAP.
 
 Files can be written to disk in all formats using `write`, and can (with some caveats)
 be written to to different formats providing file-type conversion for spatial data.
@@ -78,7 +78,7 @@ julia> url = "https://www.unidata.ucar.edu/software/netcdf/examples/tos_O1_2001-
 
 julia> filename = download(url, "tos_O1_2001-2002.nc");
 
-julia> A = NCDarray(filename)
+julia> A = geoarray(filename)
 NCDarray (named tos) with dimensions:
  Longitude (type Lon): Float64[1.0, 3.0, …, 357.0, 359.0] (Converted: Ordered Regular Intervals)
  Latitude (type Lat): Float64[-79.5, -78.5, …, 88.5, 89.5] (Converted: Ordered Regular Intervals)
@@ -115,7 +115,6 @@ Now get the mean over the timespan, then save it to disk, and plot it :
 
 ```julia
 julia> using Statistics
-
 julia> mean_tos = mean(A; dims=Ti)
 GeoArray (named tos) with dimensions:
  Longitude (type Lon): Float64[1.0, 3.0, …, 357.0, 359.0] (Converted: Ordered Regular Intervals)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,6 +27,7 @@ Mapped
 ## Array
 
 ```@docs
+geoarray
 AbstractGeoArray
 MemGeoArray
 DiskGeoArray
@@ -37,6 +38,7 @@ GeoData.OpenGeoArray
 ## Stack
 
 ```@docs
+stack
 AbstractGeoStack
 MemGeoStack
 GeoStack
@@ -48,6 +50,7 @@ SMAPstack
 ## Series
 
 ```@docs
+series
 AbstractGeoSeries
 GeoSeries
 SMAPseries

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -34,12 +34,14 @@ export AbstractGeoSeries, GeoSeries
 
 export Projected, Mapped
 
+export Lon, Lat, Vert, Band
+
 export missingval, boolmask, missingmask, replace_missing,
        aggregate, aggregate!, disaggregate, disaggregate!
 
 export crs, mappedcrs, mappedindex, mappedbounds, projectedindex, projectedbounds
 
-export Lon, Lat, Vert, Band
+export geoarray, stack, series
 
 # DimensionalData documentation urls
 const DDdocs = "https://rafaqz.github.io/DimensionalData.jl/stable/api"
@@ -63,6 +65,7 @@ include("open.jl")
 include("sources/grd.jl")
 include("show.jl")
 include("plotrecipes.jl")
+include("convenience.jl")
 
 function __init__()
     @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" begin

--- a/src/array.jl
+++ b/src/array.jl
@@ -167,8 +167,6 @@ end
 end
 
 Base.write(A::T) where T <: DiskGeoArray = write(filename(A), A)
-Base.write(filename::AbstractString, A::T) where T <: DiskGeoArray = write(filename, T, A)
-
 
 # Concrete implementation ######################################################
 

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -86,7 +86,7 @@ Write any [`AbstractGeoStack`](@ref) to file, guessing the backend from the file
 
 Keyword arguments are passed to the `write` method for the backend.
 
-If the source can't be save as a stack-like object, individual array layers will be saved.
+If the source can't be saved as a stack-like object, individual array layers will be saved.
 """
 function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
     base, ext = splitext(filename)

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -1,0 +1,186 @@
+"""
+    geoarray(filename; kw...) => AbstractGeoArray
+
+Load a file path as `AbstractGeoArray`. 
+
+# Keywords
+
+Passed to the constructor for the file type, and commmonly include:
+
+- `crs`: crs to use instead of the detected crs.
+- `mappedcrs`: CRS format like `EPSG(4326)` used in `Selectors` like `Between` and `At`, and
+    for plotting. Can be any CRS `GeoFormat` from GeoFormatTypes.jl, like `WellKnownText`.
+- `name`: `Symbol` name for the array.
+- `dims`: `Tuple` of `Dimension`s for the array. Detected automatically, but can be passed in.
+- `refdims`: `Tuple of` position `Dimension`s the array was sliced from.
+- `missingval`: Value reprsenting missing values. Detected automatically when possible, but
+    can be passed it.
+- `metadata`: `Metadata` object for the array. Detected automatically but can be passed in.
+"""
+function geoarray end
+
+geoarray(filename::AbstractString; kw...) = _constructor(geoarray, filename)(filename; kw...)
+
+"""
+    Base.write(filename::AbstractString, A::AbstractGeoArray; kw...)
+
+Write any [`AbstractGeoArray`](@ref) to file, guessing the backend from the file extension.
+
+Keyword arguments are passed to the `write` method for the backend.
+"""
+function Base.write(
+    filename::AbstractString, A::AbstractGeoArray; kw...
+)
+    write(filename, _constructor(geoarray, filename), A; kw...)
+end
+
+"""
+    stack(filename; kw...) => AbstractGeoStack
+    stack(filenames::NamedTuple; kw...) => AbstractGeoStack
+
+Load a file path or a `NamedTuple` of paths as an `AbstractGeoStack`.
+
+# Arguments
+
+- `filename`: A `NamedTuple` of stack keys and `String` filenames.
+
+# Keywords
+
+Passed to the constructor for the file type, and commmonly include:
+
+- `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
+    contained arrays when they are accessed.
+- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+- `child_kwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
+- `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
+
+```julia
+files = (:temp="temp.tif", :pressure="pressure.tif", :relhum="relhum.tif")
+stack = stack(files; child_kwargs=(mappedcrs=EPSG(4326),))
+stack[:relhum][Lat(Contains(-37), Lon(Contains(144))
+```
+"""
+function stack end
+
+stack(filename::AbstractString; kw...) = _constructor(stack, filename)(filename; kw...)
+function stack(filenames::NamedTuple; child_kwargs=(), kw...)
+    if all(x -> splitext(x)[2] == splitext(first(filenames))[2], filenames)
+        # All the same kind of file. We don't need to load them up front.
+        DiskStack(filenames; childtype=_constructor(geoarray, first(filenames)), kw...)
+    else
+        # These files are different extensions, just load them all
+        # as separate `AbstarctGeoArray` (which has some up front cost from
+        # reading the dimensions). They are probably still disk-backed for the
+        # actual array.
+        arrays = map(filenames) do fn
+            _constructor(geoarray, fn)(fn; child_kwargs...)
+        end
+        GeoStack(arrays; kw...)
+    end
+end
+
+"""
+    Base.write(filename::AbstractString, T::Type{<:AbstractGeoArray}, s::AbstractGeoStack)
+
+Write any [`AbstractGeoStack`](@ref) to file, guessing the backend from the file extension.
+
+Keyword arguments are passed to the `write` method for the backend.
+
+If the source can't be save as a stack-like object, individual array layers will be saved.
+"""
+function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
+    base, ext = splitext(filename)
+    T = _constructor(stack, filename; throw=false)
+    if T isa Nothing
+        # Save as individual `geoarray`
+        T = _constructor(geoarray, filename)
+        for key in keys(s)
+            fn = joinpath(string(base, "_", key, ext))
+            write(fn, T, s[key])
+        end
+    else
+        write(filename, _constructor(stack, filename), s; kw...)
+    end
+end
+
+"""
+    series(dirpath::AbstractString, dims; kw...) => AbstractGeoSeries
+
+Load a vector of filepaths as a `AbstractGeoSeries`. `kw` are passed to the constructor.
+
+`dims` Dimensions can hold an index matching the files in the directory,
+or a function to convert the filename strings to index values.
+"""
+function series end
+
+function series(dirnames; 
+    child=geoarray, child_kwargs=nothing, window=(), kw...
+)
+    filepaths = readdir(path)
+    if all(x -> splitext(x)[2], filenames) == splitext(first(filenames))[2]
+        # All the same kind of file. We don't need to load them up front.
+        DiskStack(filenames; childtype=_get_constructor(geoarray, first(filenames)), kw...)
+    else
+        # These files are different extensions, just load them all
+        # as separate `AbstarctGeoArray` (which has some up front cost from
+        # reading the dimensions). They are probably still disk-backed for the actual array.
+        arrays = map(filenames) do dn
+            _constructor(geoarray, fn)(fn; window=window, child_kwargs...)
+        end
+        GeoStack(arrays; kw...)
+    end
+end
+
+# Support methods
+
+function _constructor(method::Function, filename; throw=true)
+    _, extension = splitext(filename)
+    return if extension in (".grd", ".gri")
+        if method === geoarray
+            GRDarray
+        elseif method === stack
+            throw ? _no_stack_error(extension) : nothing
+        end
+    elseif extension == ".nc"
+        _check_imported(:NCDatasets, :NCDarray, extension)
+        if method === geoarray
+            NCDarray
+        else
+            NCDstack
+        end
+    elseif extension == ".h5"
+        # In future we may need to examine the file and check if
+        # it's a SMAP file or something else that uses .h5
+        _check_imported(:HDF5, :SMAPstack, extension)
+        if method === geoarray
+            throw ? _no_gearray_error(extension) : nothing
+        elseif method === stack
+            SMAPstack
+        end
+    else # GDAL handles too many extensions to list, so just try it and see if it works
+        _check_imported(:ArchGDAL, :GDALarray, extension)
+        if method === geoarray
+            GDALarray
+        elseif method === stack
+            throw ? _no_stack_error(extension) : nothing
+        end
+    end
+end
+
+_no_stack_error(ext) =
+    error("$ext files do not have named layers. Use `geoarray(filename)` to load, or `stack((key1=fn1, key2=fn2, ...)`")
+
+_no_gearray_error(ext) =
+    error("$ext files not have a single-layer implementation. Use `stack(filename)` to load")
+
+_check_imported(modulename, type, extension)  =
+    type in names(GeoData) || error("Run `import $modulename` to enable loading $extension files.")
+
+function series(dirpath::AbstractString, dims=Dim{:series}(); ext=nothing, child=geoarray, kw...)
+    filepaths = filter_ext(dirpath, ext)
+    series(filepaths, dims; child=child, kw...)
+end
+function series(filepaths::AbstractVector{<:AbstractString}, dims=Dim{:series}(); child=geoarray, kw...)
+    childtype = _constructor(child, first(filepaths))
+    GeoSeries(filepaths, dims; childtype=childtype, kw...)
+end

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -50,7 +50,7 @@ Passed to the constructor for the file type, and commmonly include:
 
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
-- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+- `metadata`: Metadata as a `StackMetadata` object.
 - `child_kwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -327,7 +327,7 @@ function _gdalwrite(filename, A, nbands, indices;
     else
         # Create a  memory object and copy it to disk, as ArchGDAL.create
         # does not support direct creation of ASCII etc. rasters
-        ArchGDAL.create("", driver=AG.getdriver("MEM"), kw...) do dataset
+        ArchGDAL.create(""; driver=AG.getdriver("MEM"), kw...) do dataset
             _gdalsetproperties!(dataset, A)
             AG.write!(dataset, data(A), indices)
             AG.copy(dataset; filename=filename, driver=gdaldriver) |> AG.destroy

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -114,13 +114,15 @@ end
 # AbstractGeoArray methods
 
 """
-    Base.write(filename::AbstractString, ::Type{GDALarray}, A::AbstractGeoArray;
-        driver="GTiff", compress="DEFLATE", tiled=true
-    )
+    Base.write(filename::AbstractString, ::Type{GDALarray}, A::AbstractGeoArray; kw...)
 
 Write a [`GDALarray`](@ref) to file, `.tif` by default, but other GDAL drivers also work.
 
-GDAL flags `driver`, `compress` and `tiled` can be passed in as keyword arguments.
+# Keywords
+
+- `driver::String`: a GDAL driver name. Guessed from the filename extension by default.
+- `compress::String`: GeoTIFF compression flag. "DEFLATE" by default.
+- `tiled::Bool`: GeoTiff tiling. Defaults to `true`.
 
 Returns `filename`.
 """

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -195,6 +195,7 @@ function GRDarray(grd::GRDattrib, filename, key=nothing;
     missingval=missingval(grd),
     metadata=metadata(grd),
 )
+    filename = first(splitext(filename))
     size_ = map(length, dims)
     T = eltype(grd)
     N = length(size_)

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -118,7 +118,7 @@ function missingval(grd::GRDattrib{T}) where T
     mv = try
         parse(T, grd.attrib["nodatavalue"])
     catch
-        @warn "No data $(missingval) is not convertible to data type $T. `missingval` set to NaN."
+        @warn "nodatavalue $(grd.attrib["nodatavalue"]) is not convertible to data type $T. `missingval` set to `missing`."
         missing
     end
 end

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -114,26 +114,6 @@ end
 
 _mapdata(f, s::AbstractGeoStack) = NamedTuple{cleankeys(keys(s))}(map(f, values(s)))
 
-"""
-    Base.write(filename::AbstractString, T::Type{<:AbstractGeoArray}, s::AbstractGeoStack)
-
-Save all layers of an `AbstractGeoStack` to separate files, using the backend determined
-by `T`.
-
-## Example
-
-```julia
-write(filename, GDALarray, A)
-```
-"""
-function Base.write(filename::AbstractString, ::Type{T}, s::AbstractGeoStack) where T <: AbstractGeoArray
-    for key in keys(s)
-        base, ext = splitext(filename)
-        fn = joinpath(string(base, "_", key, ext))
-        write(fn, T, s[key])
-    end
-end
-
 
 # Memory-based stacks ######################################################
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,7 @@
 filter_ext(path, ext::AbstractString) = filter(fn -> splitext(fn)[2] == ext, readdir(path))
 filter_ext(path, exts::Union{Tuple,AbstractArray}) = 
     filter(fn -> splitext(fn)[2] in exts, readdir(path))
+filter_ext(path, ext::Nothing) = readdir(path)
 
 maybewindow2indices(A, window::Tuple) = maybewindow2indices(A, dims(A), window::Tuple)
 maybewindow2indices(A, dims::Tuple, window::Tuple) =

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -91,22 +91,23 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
 
         @testset "2d" begin
             geoA = gdalarray[Band(1)]
-            filename = tempname() * ".tif"
+            filename = tempname() * ".asc"
             write(filename, geoA)
             saved1 = GDALarray(filename; mappedcrs=EPSG(4326))[Band(1)];
-            @test all(saved1 .== geoA)
-            @test typeof(saved1) == typeof(geoA)
-            @test val(dims(saved1, Lon)) == val(dims(geoA, Lon))
-            @test val(dims(saved1, Lat)) == val(dims(geoA, Lat))
+            @test saved1 ≈ geoA
+            @test typeof(saved1) !== typeof(geoA)
+            @test val(dims(saved1, Lon)) ≈ val(dims(geoA, Lon))
+            @test val(dims(saved1, Lat)) ≈ val(dims(geoA, Lat))
             @test all(metadata.(dims(saved1)) .== metadata.(dims(geoA)))
             @test metadata(dims(saved1)[1]) == metadata(dims(geoA)[1])
             @test missingval(saved1) === missingval(geoA) 
-            @test refdims(saved1) == refdims(geoA) end
+            @test refdims(saved1) == refdims(geoA) 
+        end
         
         @testset "3d, with subsetting" begin
             geoA2 = gdalarray[Lat(Between(33.7, 33.9)), 
                                   Lon(Between(-117.6, -117.4))]
-            filename2 = tempname() * ".asc"
+            filename2 = tempname() * ".tif"
             write(filename2, geoA2)
             saved2 = GeoArray(GDALarray(filename2; name=:test, mappedcrs=EPSG(4326)))
             @test size(saved2) == size(geoA2) == length.(dims(saved2)) == length.(dims(geoA2))
@@ -124,7 +125,7 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
             @test all(metadata.(dims(saved2)) .== metadata.(dims(geoA2)))
             @test data(saved2) == data(geoA2)
             @test typeof(saved2) == typeof(geoA2)
-            filename3 = tempname() * ".img"
+            filename3 = tempname() * ".tif"
             geoA3 = cat(gdalarray[Band(1)], gdalarray[Band(1)], gdalarray[Band(1)]; dims=Band(1:3))
             write(filename3, geoA3)
             saved3 = GeoArray(GDALarray(filename3; mappedcrs=EPSG(4326)))
@@ -133,7 +134,7 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
         end
 
         @testset "resave current" begin
-            filename = tempname() * ".tiff"
+            filename = tempname() * ".rst"
             write(filename, gdalarray)
             gdalarray2 = GDALarray(filename)
             write(gdalarray2)
@@ -254,7 +255,7 @@ end
 
     @testset "save" begin
         geoA = GeoArray(gdalstack[:a])
-        filename = tempname()
+        filename = tempname() * ".tif"
         write(filename, gdalstack)
         base, ext = splitext(filename)
         filename_b = string(base, "_b", ext)

--- a/test/sources/smap.jl
+++ b/test/sources/smap.jl
@@ -10,10 +10,10 @@ path2 = joinpath(testpath, "data/SMAP_L4_SM_gph_20160102T223000_Vv4011_001.h5")
 
 if isfile(path1) && isfile(path2)
     @testset "stack" begin
-        stack = SMAPstack(path1)
+        smapstack = stack(path1)
 
         @testset "conversion to GeoArray" begin
-            smaparray = stack["soil_temp_layer1"][Lat(), Lon()]
+            smaparray = smapstack["soil_temp_layer1"][Lat(), Lon()]
             @test smaparray isa GeoArray{Float32,2}
             @test dims(smaparray) isa Tuple{<:Lon{<:Array{Float32,1}}, <:Lat{<:Array{Float32,1}}}
             @test span(smaparray) isa Tuple{Irregular{Tuple{Float32,Float32}},Irregular{Tuple{Float32,Float32}}}
@@ -26,7 +26,7 @@ if isfile(path1) && isfile(path2)
             @test name(smaparray) == :soil_temp_layer1
             dt = DateTime(2016, 1, 1, 22, 30)
             step_ = Hour(3)
-            @test refdims(stack) ==
+            @test refdims(smapstack) ==
                 (Ti(dt:step_:dt; mode=Sampled(Ordered(), Regular(step_), Intervals(Start()))),)
             # Currently empty
             @test metadata(smaparray) isa SMAPstackMetadata
@@ -37,17 +37,17 @@ if isfile(path1) && isfile(path2)
             # This uses too much ram! There is a lingering memory leak in HDF5.
             # geostack = GeoStack(stack)
             # @test Symbol.(Tuple(keys(stack))) == keys(geostack)
-            geostack = GeoStack(stack; keys=(:baseflow_flux, :snow_mass, :soil_temp_layer1))
+            geostack = GeoStack(smapstack; keys=(:baseflow_flux, :snow_mass, :soil_temp_layer1))
             @test keys(geostack) == (:baseflow_flux, :snow_mass, :soil_temp_layer1)
         end
 
         if VERSION > v"1.1-"
             @testset "copy" begin
-                geoarray = zero(stack[:soil_temp_layer1])
-                @test geoarray isa GeoArray
-                @test geoarray != stack[:soil_temp_layer1]
-                copy!(geoarray, stack, :soil_temp_layer1)
-                @test geoarray == stack[:soil_temp_layer1]
+                geoA = zero(smapstack[:soil_temp_layer1])
+                @test geoA isa GeoArray
+                @test geoA != smapstack[:soil_temp_layer1]
+                copy!(geoA, smapstack, :soil_temp_layer1)
+                @test geoA == smapstack[:soil_temp_layer1]
             end
         end
 
@@ -72,13 +72,13 @@ if isfile(path1) && isfile(path2)
         end
 
         @testset "show" begin
-            sh1 = sprint(show, stack[:soil_temp_layer1])
+            sh1 = sprint(show, smapstack[:soil_temp_layer1])
             # Test but don't lock this down too much
             @test occursin("GeoArray", sh1)
             @test occursin("Latitude", sh1)
             @test occursin("Longitude", sh1)
             @test occursin("Time", sh1)
-            sh2 = sprint(show, stack[:soil_temp_layer1][Lat(Between(0, 100)), Lon(Between(1, 100))])
+            sh2 = sprint(show, smapstack[:soil_temp_layer1][Lat(Between(0, 100)), Lon(Between(1, 100))])
             # Test but don't lock this down too much
             @test occursin("GeoArray", sh2)
             @test occursin("Latitude", sh2)


### PR DESCRIPTION
This PR should make it easier to construct various geoarrays, stacks and series. The methods `geoarray`, `stack` and `series` guess the backend constructors from the file extension, instead of having to specify them manually.