### PR TITLE
Netcdf bounds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 Adapt = "2, 3.0"
 ArchGDAL = "0.6"
-DimensionalData = "0.16"
+DimensionalData = "^0.16.6"
 GeoFormatTypes = "^0.2.1, 0.3"
 HDF5 = "0.14, 0.15"
 Missings = "0.4"

--- a/src/dimensions.jl
+++ b/src/dimensions.jl
@@ -1,3 +1,6 @@
+
+const SpatialDim = Union{XDim,YDim,ZDim}
+
 """
     Band <: Dimension
 

--- a/src/mode.jl
+++ b/src/mode.jl
@@ -108,7 +108,7 @@ Other dimension modes pass through unchanged.
 
 This is used to e.g. save a netcdf file to GeoTiff.
 """
-convertmode(dstmode::Type{<:IndexMode}, A::AbstractArray) =
+convertmode(dstmode::Type{<:IndexMode}, A::AbstractDimArray) =
     rebuild(A, data(A), convertmode(dstmode, dims(A)))
 convertmode(dstmode::Type{<:IndexMode}, dims::Tuple) =
     map(d -> convertmode(dstmode, d), dims)

--- a/src/plotrecipes.jl
+++ b/src/plotrecipes.jl
@@ -1,8 +1,6 @@
 struct GeoPlot end
 struct GeoZPlot end
 
-const SpatialDim = Union{XDim,YDim,ZDim}
-
 # We only look at arrays with X, Y, Z dims here.
 # Otherwise they fall back to DimensionalData.jl recipes
 @recipe function f(A::AbstractGeoArray)
@@ -91,7 +89,7 @@ end
 
 # Plots heatmaps pixels are centered.
 # So we should center, and use the projected value.
-_prepare(d::Dimension) = shiftindexloci(Center(), d) |> _maybe_mapped |> index
+_prepare(d::Dimension) = d |> _maybe_shift |> _maybe_mapped |> index
 # Convert arrays to a consistent missing value and Forward array order
 _prepare(A::AbstractGeoArray) =
     _maybe_replace_missing(A) |>
@@ -106,6 +104,10 @@ _maybename(n::NoName) = ""
 
 _maybe_replace_missing(A::AbstractArray{<:AbstractFloat}) = replace_missing(A, eltype(A)(NaN))
 _maybe_replace_missing(A) = A
+
+_maybe_shift(d) = _maybe_shift(sampling(d), d)
+_maybe_shift(::Intervals, d) = DD.maybeshiftlocus(Center(), d)
+_maybe_shift(sampling, d) = d
 
 _maybe_mapped(dims::Tuple) = map(_maybe_mapped, dims)
 _maybe_mapped(dim::Dimension) = _maybe_mapped(mode(dim), dim)

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -81,26 +81,26 @@ function DD.dims(grd::GRDattrib, crs=nothing, mappedcrs=nothing)
     yspan = (ybounds[2] - ybounds[1]) / nrows
 
     # Not fully implemented yet
-    latlon_metadata = GRDdimMetadata(Dict())
+    xy_metadata = GRDdimMetadata(Dict())
 
-    latmode = Projected(
-        order=Ordered(GRD_INDEX_ORDER, GRD_Y_ARRAY, GRD_Y_RELATION),
-        span=Regular(yspan),
-        sampling=Intervals(Start()),
-        crs=crs,
-        mappedcrs=mappedcrs,
-    )
-    lonmode = Projected(
+    xmode = Projected(
         order=Ordered(GRD_INDEX_ORDER, GRD_X_ARRAY, GRD_X_RELATION),
         span=Regular(xspan),
         sampling=Intervals(Start()),
         crs=crs,
         mappedcrs=mappedcrs,
     )
-    lat = Y(LinRange(ybounds[1], ybounds[2] - yspan, nrows), latmode, latlon_metadata)
-    lon = X(LinRange(xbounds[1], xbounds[2] - xspan, ncols), lonmode, latlon_metadata)
+    ymode = Projected(
+        order=Ordered(GRD_INDEX_ORDER, GRD_Y_ARRAY, GRD_Y_RELATION),
+        span=Regular(yspan),
+        sampling=Intervals(Start()),
+        crs=crs,
+        mappedcrs=mappedcrs,
+    )
+    x = X(LinRange(xbounds[1], xbounds[2] - xspan, ncols), xmode, xy_metadata)
+    y = Y(LinRange(ybounds[1], ybounds[2] - yspan, nrows), ymode, xy_metadata)
     band = Band(1:nbands; mode=Categorical(Ordered()))
-    lon, lat, band
+    x, y, band
 end
 
 function DD.metadata(grd::GRDattrib, args...)

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -341,7 +341,7 @@ function _ncdmode(index::AbstractArray{<:Number}, dimtype, crs, mappedcrs, metad
     # Unless its a time dimension.
     order = _ncdorder(index)
     span = _ncdspan(index, order)
-    sampling = Intervals(Center())
+    sampling = Points()
     if dimtype in (Y, X)
         # If the index is regularly spaced and there is no crs
         # then there is probably just one crs - the mappedcrs
@@ -397,7 +397,7 @@ function _get_period(index, metadata::NCDdimMetadata)
         period = _parse_period(metadata[:delta_t])
         period isa Nothing || return Regular(period), Points()
     elseif haskey(metadata, :avg_period)
-        period = _nc_parse_period(metadata[:avg_period])
+        period = _parse_period(metadata[:avg_period])
         period isa Nothing || return Regular(period), Intervals(Center())
     end
     return sampling = Irregular(), Points()
@@ -440,13 +440,11 @@ function _ncwritevar!(dataset, A::AbstractGeoArray{T,N}) where {T,N}
     for dim in dims(A)
         key = lowercase(string(name(dim)))
         haskey(dataset.dim, key) && continue
-
         # Shift index before conversion to Mapped
         dim = _ncshiftindex(dim)
         if dim isa Y || dim isa X
             dim = convertmode(Mapped, dim)
         end
-
         md = metadata(dim)
         # TODO handle dim attribs
         attribvec = [] #md isa Nothing ? [] : [val(md)...]

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -55,5 +55,6 @@ end
     A = DimArray(zeros(length(lon), length(lat)), (lon, lat))
     Aconv = convertmode(Mapped, A)
 
-    @test dims(Aconv) == (convertedlon, convertedlat)
+    @test index(Aconv) == (index(convertedlon), index(convertedlat))
+    @test val.(span(Aconv)) == val.(span.((convertedlon, convertedlat)))
 end

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -1,8 +1,9 @@
 using GeoData, Test, Statistics, Dates, Plots
 import NCDatasets, ArchGDAL
-using GeoData: name, mode, window, DiskStack
+using GeoData: name, mode, window, DiskStack, bounds
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
+const DD = DimensionalData
 
 maybedownload("https://raw.githubusercontent.com/rspatial/raster/master/inst/external/rlogo.grd", "rlogo.grd")
 maybedownload("https://github.com/rspatial/raster/raw/master/inst/external/rlogo.gri", "rlogo.gri")
@@ -132,6 +133,7 @@ path = stem * ".gri"
 
         @testset "to netcdf" begin
             filename2 = tempname()
+            span(grdarray[Band(1)])
             write(filename2, NCDarray, grdarray[Band(1)])
             saved = GeoArray(NCDarray(filename2; crs=crs(grdarray)))
             @test size(saved) == size(grdarray[Band(1)])

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,22 +1,7 @@
 using GeoData, Test
-using GeoData: cleankeys, shiftindexloci
+using GeoData: cleankeys
 
 @testset "cleankeys" begin
     @test cleankeys(["a", "b", "c"]) == (:a, :b, :c)
     @test cleankeys(("a", "b", "c")) == (:a, :b, :c)
-end
-
-@testset "shiftindexloci" begin
-    dim = X(1.0:3.0; mode=Sampled(Ordered(), Regular(1.0), Intervals(Center())))
-    @test val(shiftindexloci(Start(), dim)) == 0.5:1.0:2.5
-    @test val(shiftindexloci(End(), dim)) == 1.5:1.0:3.5
-    @test val(shiftindexloci(Center(), dim)) == 1.0:1.0:3.0
-    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(Start())))
-    @test val(shiftindexloci(End(), dim)) == [4, 5, 6]
-    @test val(shiftindexloci(Center(), dim)) == [3.5, 4.5, 5.5]
-    @test val(shiftindexloci(Start(), dim)) == [3, 4, 5]
-    dim = X([3, 4, 5]; mode=Sampled(Ordered(), Regular(1), Intervals(End())))
-    @test val(shiftindexloci(End(), dim)) == [3, 4, 5]
-    @test val(shiftindexloci(Center(), dim)) == [2.5, 3.5, 4.5]
-    @test val(shiftindexloci(Start(), dim)) == [2, 3, 4]
 end


### PR DESCRIPTION
This PR adds handling for netcdf bounds matrices using an `Explicit` span.

This means `bounds` are now accurate, and `Between/Contains` selectors should be correct when there are bounds matrices available. Without a bounds matrix present, sampling now defaults to `Points`, as it should in CF standards - so `Between` will also be correct for `Points`.

Thanks @Alexander-Barth for making this possible with changes to NCDatasets.jl.

Closes #104 