### PR TITLE
Labelled metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [compat]
 Adapt = "2, 3.0"
 ArchGDAL = "0.6"
-DimensionalData = "^0.16.7"
+DimensionalData = "0.17"
 GeoFormatTypes = "^0.2.1, 0.3"
 HDF5 = "0.14, 0.15"
 Missings = "0.4"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -82,8 +82,6 @@ If ArchGDAL.jl is loaded (to enable reprojection), they can have [`mappedcrs`](@
 ```@docs
 GRDarray
 GRDstack
-GRDdimMetadata
-GRDarrayMetadata
 ```
 
 ## NetCDF
@@ -99,9 +97,6 @@ Single files can be treated as a array or a stack of arrays.
 ```@docs
 NCDarray
 NCDstack
-NCDdimMetadata
-NCDarrayMetadata
-NCDstackMetadata
 ```
 
 ## GDAL
@@ -116,8 +111,6 @@ import ArchGDAL
 ```@docs
 GDALarray
 GDALstack
-GDALdimMetadata
-GDALarrayMetadata
 ```
 
 ## SMAP
@@ -137,9 +130,6 @@ using [`SMAPseries`](@ref). Methods like `aggregate` can be done over whole
 folders of stacks of data with a single command.
 
 ```@docs
-SMAPdimMetadata
-SMAParrayMetadata
-SMAPstackMetadata
 SMAPstack
 SMAPseries
 ```

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -34,7 +34,11 @@ export AbstractGeoSeries, GeoSeries
 
 export Projected, Mapped
 
+<<<<<<< HEAD
 export Band, Lat, Lon, Vert, GeoXDim, GeoYDim, GeoZDim
+=======
+export Lon, Lat, Vert, Band
+>>>>>>> bf3edfc (add convenience methods and test)
 
 export missingval, boolmask, missingmask, replace_missing,
        aggregate, aggregate!, disaggregate, disaggregate!
@@ -42,6 +46,7 @@ export missingval, boolmask, missingmask, replace_missing,
 export crs, mappedcrs, mappedindex, mappedbounds, projectedindex, projectedbounds
 
 export geoarray, stack, series
+<<<<<<< HEAD
 
 
 const Lon = X
@@ -50,6 +55,8 @@ const Vert = Z
 const GeoXDim = XDim 
 const GeoYDim = YDim 
 const GeoZDim = ZDim 
+=======
+>>>>>>> bf3edfc (add convenience methods and test)
 
 # DimensionalData documentation urls
 const DDdocs = "https://rafaqz.github.io/DimensionalData.jl/stable/api"

--- a/src/GeoData.jl
+++ b/src/GeoData.jl
@@ -24,8 +24,6 @@ using Base: tail, @propagate_inbounds
 
 using DimensionalData: StandardIndices
 
-export Metadata, DimMetadata, ArrayMetadata, StackMetadata
-
 export AbstractGeoArray, MemGeoArray, DiskGeoArray, GeoArray
 
 export AbstractGeoStack, MemGeoStack, DiskGeoStack, DiskStack, GeoStack
@@ -34,11 +32,7 @@ export AbstractGeoSeries, GeoSeries
 
 export Projected, Mapped
 
-<<<<<<< HEAD
 export Band, Lat, Lon, Vert, GeoXDim, GeoYDim, GeoZDim
-=======
-export Lon, Lat, Vert, Band
->>>>>>> bf3edfc (add convenience methods and test)
 
 export missingval, boolmask, missingmask, replace_missing,
        aggregate, aggregate!, disaggregate, disaggregate!
@@ -46,7 +40,6 @@ export missingval, boolmask, missingmask, replace_missing,
 export crs, mappedcrs, mappedindex, mappedbounds, projectedindex, projectedbounds
 
 export geoarray, stack, series
-<<<<<<< HEAD
 
 
 const Lon = X
@@ -55,8 +48,6 @@ const Vert = Z
 const GeoXDim = XDim 
 const GeoYDim = YDim 
 const GeoZDim = ZDim 
-=======
->>>>>>> bf3edfc (add convenience methods and test)
 
 # DimensionalData documentation urls
 const DDdocs = "https://rafaqz.github.io/DimensionalData.jl/stable/api"

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -50,11 +50,7 @@ Passed to the constructor for the file type, and commmonly include:
 
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
-<<<<<<< HEAD
-- `metadata`: Metadata as a `StackMetadata` object.
-=======
-- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
->>>>>>> bf3edfc (add convenience methods and test)
+- `metadata`: `Metadata` as object.
 - `child_kwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 
@@ -90,11 +86,7 @@ Write any [`AbstractGeoStack`](@ref) to file, guessing the backend from the file
 
 Keyword arguments are passed to the `write` method for the backend.
 
-<<<<<<< HEAD
 If the source can't be saved as a stack-like object, individual array layers will be saved.
-=======
-If the source can't be save as a stack-like object, individual array layers will be saved.
->>>>>>> bf3edfc (add convenience methods and test)
 """
 function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
     base, ext = splitext(filename)
@@ -112,7 +104,6 @@ function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
 end
 
 """
-<<<<<<< HEAD
     series(dirpath::AbstractString, dims; ext, child=geoarray, kw...) => AbstractGeoSeries
     series(filenames::AbstractVector{String}, dims; child=geoarray, kw...) => AbstractGeoSeries
 
@@ -140,38 +131,10 @@ end
 function series(filepaths::AbstractVector{<:AbstractString}, dims=(Dim{:series}(),); child=geoarray, kw...)
     childtype = _constructor(child, first(filepaths))
     GeoSeries(filepaths, dims; childtype=childtype, kw...)
-=======
-    series(dirpath::AbstractString, dims; kw...) => AbstractGeoSeries
-
-Load a vector of filepaths as a `AbstractGeoSeries`. `kw` are passed to the constructor.
-
-`dims` Dimensions can hold an index matching the files in the directory,
-or a function to convert the filename strings to index values.
-"""
-function series end
-
-function series(dirnames; 
-    child=geoarray, child_kwargs=nothing, window=(), kw...
-)
-    filepaths = readdir(path)
-    if all(x -> splitext(x)[2], filenames) == splitext(first(filenames))[2]
-        # All the same kind of file. We don't need to load them up front.
-        DiskStack(filenames; childtype=_get_constructor(geoarray, first(filenames)), kw...)
-    else
-        # These files are different extensions, just load them all
-        # as separate `AbstarctGeoArray` (which has some up front cost from
-        # reading the dimensions). They are probably still disk-backed for the actual array.
-        arrays = map(filenames) do dn
-            _constructor(geoarray, fn)(fn; window=window, child_kwargs...)
-        end
-        GeoStack(arrays; kw...)
-    end
->>>>>>> bf3edfc (add convenience methods and test)
 end
 
 # Support methods
 
-<<<<<<< HEAD
 const EXT = (GRD=(".grd", ".gri"), NCD=".nc", SMAP=".h5")
 
 # The the constructor for a geoarray or stack, based on the
@@ -205,39 +168,6 @@ function _constructor(method::typeof(stack), filename; throw=true)
         SMAPstack
     else
         throw ? _no_stack_error(extension) : nothing
-=======
-function _constructor(method::Function, filename; throw=true)
-    _, extension = splitext(filename)
-    return if extension in (".grd", ".gri")
-        if method === geoarray
-            GRDarray
-        elseif method === stack
-            throw ? _no_stack_error(extension) : nothing
-        end
-    elseif extension == ".nc"
-        _check_imported(:NCDatasets, :NCDarray, extension)
-        if method === geoarray
-            NCDarray
-        else
-            NCDstack
-        end
-    elseif extension == ".h5"
-        # In future we may need to examine the file and check if
-        # it's a SMAP file or something else that uses .h5
-        _check_imported(:HDF5, :SMAPstack, extension)
-        if method === geoarray
-            throw ? _no_gearray_error(extension) : nothing
-        elseif method === stack
-            SMAPstack
-        end
-    else # GDAL handles too many extensions to list, so just try it and see if it works
-        _check_imported(:ArchGDAL, :GDALarray, extension)
-        if method === geoarray
-            GDALarray
-        elseif method === stack
-            throw ? _no_stack_error(extension) : nothing
-        end
->>>>>>> bf3edfc (add convenience methods and test)
     end
 end
 
@@ -247,7 +177,6 @@ _no_stack_error(ext) =
 _no_gearray_error(ext) =
     error("$ext files not have a single-layer implementation. Use `stack(filename)` to load")
 
-<<<<<<< HEAD
 function _check_imported(modulename, type, extension; throw=true)
     if type in names(GeoData)
         true
@@ -258,16 +187,4 @@ function _check_imported(modulename, type, extension; throw=true)
             false
         end
     end
-=======
-_check_imported(modulename, type, extension)  =
-    type in names(GeoData) || error("Run `import $modulename` to enable loading $extension files.")
-
-function series(dirpath::AbstractString, dims=Dim{:series}(); ext=nothing, child=geoarray, kw...)
-    filepaths = filter_ext(dirpath, ext)
-    series(filepaths, dims; child=child, kw...)
-end
-function series(filepaths::AbstractVector{<:AbstractString}, dims=Dim{:series}(); child=geoarray, kw...)
-    childtype = _constructor(child, first(filepaths))
-    GeoSeries(filepaths, dims; childtype=childtype, kw...)
->>>>>>> bf3edfc (add convenience methods and test)
 end

--- a/src/convenience.jl
+++ b/src/convenience.jl
@@ -50,7 +50,11 @@ Passed to the constructor for the file type, and commmonly include:
 
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
+<<<<<<< HEAD
 - `metadata`: Metadata as a `StackMetadata` object.
+=======
+- `metadata`: Metadata as a [`StackMetadata`](@ref) object.
+>>>>>>> bf3edfc (add convenience methods and test)
 - `child_kwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 
@@ -86,7 +90,11 @@ Write any [`AbstractGeoStack`](@ref) to file, guessing the backend from the file
 
 Keyword arguments are passed to the `write` method for the backend.
 
+<<<<<<< HEAD
 If the source can't be saved as a stack-like object, individual array layers will be saved.
+=======
+If the source can't be save as a stack-like object, individual array layers will be saved.
+>>>>>>> bf3edfc (add convenience methods and test)
 """
 function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
     base, ext = splitext(filename)
@@ -104,6 +112,7 @@ function Base.write(filename::AbstractString, s::AbstractGeoStack; kw...)
 end
 
 """
+<<<<<<< HEAD
     series(dirpath::AbstractString, dims; ext, child=geoarray, kw...) => AbstractGeoSeries
     series(filenames::AbstractVector{String}, dims; child=geoarray, kw...) => AbstractGeoSeries
 
@@ -131,10 +140,38 @@ end
 function series(filepaths::AbstractVector{<:AbstractString}, dims=(Dim{:series}(),); child=geoarray, kw...)
     childtype = _constructor(child, first(filepaths))
     GeoSeries(filepaths, dims; childtype=childtype, kw...)
+=======
+    series(dirpath::AbstractString, dims; kw...) => AbstractGeoSeries
+
+Load a vector of filepaths as a `AbstractGeoSeries`. `kw` are passed to the constructor.
+
+`dims` Dimensions can hold an index matching the files in the directory,
+or a function to convert the filename strings to index values.
+"""
+function series end
+
+function series(dirnames; 
+    child=geoarray, child_kwargs=nothing, window=(), kw...
+)
+    filepaths = readdir(path)
+    if all(x -> splitext(x)[2], filenames) == splitext(first(filenames))[2]
+        # All the same kind of file. We don't need to load them up front.
+        DiskStack(filenames; childtype=_get_constructor(geoarray, first(filenames)), kw...)
+    else
+        # These files are different extensions, just load them all
+        # as separate `AbstarctGeoArray` (which has some up front cost from
+        # reading the dimensions). They are probably still disk-backed for the actual array.
+        arrays = map(filenames) do dn
+            _constructor(geoarray, fn)(fn; window=window, child_kwargs...)
+        end
+        GeoStack(arrays; kw...)
+    end
+>>>>>>> bf3edfc (add convenience methods and test)
 end
 
 # Support methods
 
+<<<<<<< HEAD
 const EXT = (GRD=(".grd", ".gri"), NCD=".nc", SMAP=".h5")
 
 # The the constructor for a geoarray or stack, based on the
@@ -168,6 +205,39 @@ function _constructor(method::typeof(stack), filename; throw=true)
         SMAPstack
     else
         throw ? _no_stack_error(extension) : nothing
+=======
+function _constructor(method::Function, filename; throw=true)
+    _, extension = splitext(filename)
+    return if extension in (".grd", ".gri")
+        if method === geoarray
+            GRDarray
+        elseif method === stack
+            throw ? _no_stack_error(extension) : nothing
+        end
+    elseif extension == ".nc"
+        _check_imported(:NCDatasets, :NCDarray, extension)
+        if method === geoarray
+            NCDarray
+        else
+            NCDstack
+        end
+    elseif extension == ".h5"
+        # In future we may need to examine the file and check if
+        # it's a SMAP file or something else that uses .h5
+        _check_imported(:HDF5, :SMAPstack, extension)
+        if method === geoarray
+            throw ? _no_gearray_error(extension) : nothing
+        elseif method === stack
+            SMAPstack
+        end
+    else # GDAL handles too many extensions to list, so just try it and see if it works
+        _check_imported(:ArchGDAL, :GDALarray, extension)
+        if method === geoarray
+            GDALarray
+        elseif method === stack
+            throw ? _no_stack_error(extension) : nothing
+        end
+>>>>>>> bf3edfc (add convenience methods and test)
     end
 end
 
@@ -177,6 +247,7 @@ _no_stack_error(ext) =
 _no_gearray_error(ext) =
     error("$ext files not have a single-layer implementation. Use `stack(filename)` to load")
 
+<<<<<<< HEAD
 function _check_imported(modulename, type, extension; throw=true)
     if type in names(GeoData)
         true
@@ -187,4 +258,16 @@ function _check_imported(modulename, type, extension; throw=true)
             false
         end
     end
+=======
+_check_imported(modulename, type, extension)  =
+    type in names(GeoData) || error("Run `import $modulename` to enable loading $extension files.")
+
+function series(dirpath::AbstractString, dims=Dim{:series}(); ext=nothing, child=geoarray, kw...)
+    filepaths = filter_ext(dirpath, ext)
+    series(filepaths, dims; child=child, kw...)
+end
+function series(filepaths::AbstractVector{<:AbstractString}, dims=Dim{:series}(); child=geoarray, kw...)
+    childtype = _constructor(child, first(filepaths))
+    GeoSeries(filepaths, dims; childtype=childtype, kw...)
+>>>>>>> bf3edfc (add convenience methods and test)
 end

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -10,36 +10,7 @@ const GDAL_RELATION = ForwardRelation()
 const GDAL_X_LOCUS = Start()
 const GDAL_Y_LOCUS = Start()
 
-export GDALarray, GDALstack, GDALarrayMetadata, GDALdimMetadata
-
-# Metadata ########################################################################
-
-"""
-    GDALdimMetadata <: AbstractDimMetadata
-
-    GDALdimMetadata(val::Union{Dict,NamedTuple})
-    GDALdimMetadata(pairs::Pair...) => GDALdimMetadata{Dict}
-    GDALdimMetadata(; kw...) => GDALdimMetadata{NamedTuple}
-
-`Metadata` wrapper for `GDALarray` dimensions.
-"""
-struct GDALdimMetadata{T} <: AbstractDimMetadata{T}
-    val::T
-end
-
-"""
-    GDALarrayMetadata <: AbstractArrayMetadata
-
-    GDALarrayMetadata(val::Union{Dict,NamedTuple})
-    GDALarrayMetadata(pairs::Pair...) => GDALarrayMetadata{Dict}
-    GDALarrayMetadata(; kw...) => GDALarrayMetadata{NamedTuple}
-
-`Metadata` wrapper for `GDALarray`.
-"""
-struct GDALarrayMetadata{T} <: AbstractArrayMetadata{T}
-    val::T
-end
-
+export GDALarray, GDALstack
 
 # Array ########################################################################
 
@@ -67,7 +38,7 @@ immediately.
 - `missingval`: Value reprsenting missing values. Detected automatically when possible, but
     can be passed it.
 - `metadata`: `Metadata` object for the array. Detected automatically as
-    [`GDALarrayMetadata`](@ref), but can be passed in.
+    `Metadata{:GDAL}`, but can be passed in.
 
 # Example
 
@@ -179,7 +150,7 @@ Load a stack of files lazily from disk.
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
-- `metadata`: a `DimensionalData.StackMetadata` object.
+- `metadata`: a `DimensionalData.Metadata` object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 
@@ -209,8 +180,7 @@ function DD.dims(raster::AG.RasterDataset, crs=nothing, mappedcrs=nothing)
     nbands = AG.nraster(raster)
     band = Band(1:nbands, mode=Categorical(Ordered()))
     crs = crs isa Nothing ? GeoData.crs(raster) : crs
-
-    xy_metadata = GDALdimMetadata()
+    xy_metadata = Metadata{:GDAL}()
 
     # Output Sampled index dims when the transformation is lat/lon alligned,
     # otherwise use Transformed index, with an affine map.
@@ -271,7 +241,7 @@ function DD.metadata(raster::AG.RasterDataset, args...)
     path = first(AG.filelist(raster))
     units = AG.getunittype(band)
     upair = units == "" ? () : (:units=>units,)
-    GDALarrayMetadata(Dict(:filepath=>path, :scale=>scale, :offset=>offset, upair...))
+    Metadata{:GDAL}(Dict(:filepath=>path, :scale=>scale, :offset=>offset, upair...))
 end
 
 function missingval(raster::AG.RasterDataset, args...)

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -1,4 +1,4 @@
-export GRDarray, GRDstack, GRDdimMetadata, GRDarrayMetadata
+export GRDarray, GRDstack
 
 const GRD_INDEX_ORDER = ForwardIndex()
 const GRD_X_ARRAY = ForwardArray()
@@ -21,35 +21,6 @@ const GRD_DATATYPE_TRANSLATION = Dict{String, DataType}(
 )
 const REV_GRD_DATATYPE_TRANSLATION =
     Dict{DataType, String}(v => k for (k,v) in GRD_DATATYPE_TRANSLATION)
-
-# Metadata ########################################################################
-
-"""
-    GRDdimMetadata <: AbstractDimMetadata
-
-    GRDdimMetadata(val::Union{Dict,NamedTuple})
-    GRDdimMetadata(pairs::Pair...) => GRDdimMetadata{Dict}
-    GRDdimMetadata(; kw...) => GRDdimMetadata{NamedTuple}
-
-`Metadata` wrapper for `GRDarray` dimension metadata.
-"""
-struct GRDdimMetadata{T} <: AbstractDimMetadata{T}
-    val::T
-end
-
-"""
-    GRDarrayMetadata <: AbstractArrayMetadata
-
-    GRDarrayMetadata(val::Union{Dict,NamedTuple})
-    GRDarrayMetadata(pairs::Pair...) => GRDarrayMetadata{Dict}
-    GRDarrayMetadata(; kw...) => GRDarrayMetadata{NamedTuple}
-
-`Metadata` wrapper for `GRDarray` metadata.
-"""
-struct GRDarrayMetadata{T} <: AbstractArrayMetadata{T}
-    val::T
-end
-
 
 # GRD attributes wrapper. Only used during file load, for dispatch.
 struct GRDattrib{T,F,A}
@@ -81,7 +52,7 @@ function DD.dims(grd::GRDattrib, crs=nothing, mappedcrs=nothing)
     yspan = (ybounds[2] - ybounds[1]) / nrows
 
     # Not fully implemented yet
-    xy_metadata = GRDdimMetadata(Dict())
+    xy_metadata = Metadata{:GRD}(Dict())
 
     xmode = Projected(
         order=Ordered(GRD_INDEX_ORDER, GRD_X_ARRAY, GRD_X_RELATION),
@@ -104,7 +75,7 @@ function DD.dims(grd::GRDattrib, crs=nothing, mappedcrs=nothing)
 end
 
 function DD.metadata(grd::GRDattrib, args...)
-    metadata = GRDarrayMetadata()
+    metadata = Metadata{:GRD}()
     for key in ("creator", "created", "history")
         val = get(grd.attrib, key, "")
         if val != ""
@@ -164,7 +135,7 @@ A [`DiskGeoArray`](@ref) that loads .grd files lazily from disk.
 - `missingval`: Value reprsenting missing values. Detected automatically when possible, but
     can be passed it.
 - `metadata`: `Metadata` object for the array. Detected automatically as
-    [`GRDarrayMetadata`](@ref), but can be passed in.
+    `Metadata{:GRD}`, but can be passed in.
 
 ## Example
 
@@ -300,7 +271,7 @@ Convenience method to create a DiskStack of [`GRDarray`](@ref) from `filenames`.
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
-- `metadata`: Metadata as a `StackMetadata` object.
+- `metadata`: A `Metadata` object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 

--- a/src/sources/ncdatasets.jl
+++ b/src/sources/ncdatasets.jl
@@ -62,7 +62,7 @@ future, including detecting and converting the native NetCDF projection format.
 - `missingval`: Value reprsenting missing values. Detected automatically when possible, but
   can be passed it.
 - `metadata`: `Metadata` object for the array. Detected automatically as
-  [`Metadata{:NCD}`](@ref), but can be passed in.
+  `Metadata{:NCD}`, but can be passed in.
 
 ## Example
 

--- a/src/sources/smap.jl
+++ b/src/sources/smap.jl
@@ -1,54 +1,15 @@
 using .HDF5
 
-export SMAPstack, SMAPseries, SMAPdimMetadata, SMAParrayMetadata, SMAPstackMetadata
+export SMAP, SMAPstack, SMAPseries
 
 const SMAPMISSING = -9999.0
 const SMAPGEODATA = "Geophysical_Data"
 const SMAPCRS = ProjString("+proj=cea +lon_0=0 +lat_ts=30 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0")
 
-"""
-    SMAPdimMetadata <: AbstractDimMetadata
-
-    SMAPdimMetadata(val::Union{Dict,NamedTuple})
-    SMAPdimMetadata(pairs::Pair...) => SMAPdimMetadata{Dict}
-    SMAPdimMetadata(; kw...) => SMAPdimMetadata{NamedTuple}
-
-`DimMetadata` wrapper for `SMAParray` dimensions.
-"""
-struct SMAPdimMetadata{T} <: AbstractDimMetadata{T}
-    val::T
-end
-
-"""
-    SMAParrayMetadata <: AbstractArrayMetadata
-
-    SMAParrayMetadata(val::Union{Dict,NamedTuple})
-    SMAParrayMetadata(pairs::Pair...) => SMAParrayMetadata{Dict}
-    SMAParrayMetadata(; kw...) => SMAParrayMetadata{NamedTuple}
-
-`ArrayMetadata` wrapper for `SMAParray`.
-"""
-struct SMAParrayMetadata{T} <: AbstractArrayMetadata{T}
-    val::T
-end
-
-"""
-    SMAPstackMetadata <: AbstractStackMetadata
-
-    SMAPstackMetadata(val::Union{Dict,NamedTuple})
-    SMAPstackMetadata(pairs::Pair...) => SMAPstackMetadata{Dict}
-    SMAPstackMetadata(; kw...) => SMAPstackMetadata{NamedTuple}
-
-`StackMetadata` wrapper for `SMAPstack`.
-"""
-struct SMAPstackMetadata{T} <: AbstractStackMetadata{T}
-    val::T
-end
-
 # Stack ########################################################################
 
 """
-    SMAPstacka <: DiskGeoStack
+    SMAPstack <: DiskGeoStack
 
     SMAPstack(filename::String; dims=nothing, refdims=nothing, window=())
 
@@ -67,7 +28,7 @@ so we store them as stack fields.
     These are loaded from the HDF5 by default, but can be passed in to improve performance,
     as is done by [`SMAPseries`](@ref),
 - `refdims`: As for `dims`. Often the position time `Dimension` from the `SMAPseries`.
-- `metadata`: [`SMAPstackMetadata`](@ref) object. As for `dims`.
+- `metadata`: [`Metadata`](@ref) object. As for `dims`.
 - `window`: Like `view` but lazy, for disk based data. Can be a tuple of Dimensions,
     selectors or regular indices. These will be applied when the data is loaded or indexed.
 """
@@ -220,7 +181,7 @@ _smap_timedim(times::AbstractVector) =
     Ti(times, mode=Sampled(Ordered(), Regular(Hour(3)), Intervals(Start())))
 
 # TODO actually add metadata to the dict
-_smapmetadata(dataset::HDF5.File) = SMAPstackMetadata(Dict())
+_smapmetadata(dataset::HDF5.File) = Metadata{:SMAP}(Dict())
 
 function _smapdims(dataset::HDF5.File)
     proj = read(HDF5.attributes(HDF5.root(dataset)["EASE2_global_projection"]), "grid_mapping_name")

--- a/src/sources/smap.jl
+++ b/src/sources/smap.jl
@@ -28,7 +28,7 @@ so we store them as stack fields.
     These are loaded from the HDF5 by default, but can be passed in to improve performance,
     as is done by [`SMAPseries`](@ref),
 - `refdims`: As for `dims`. Often the position time `Dimension` from the `SMAPseries`.
-- `metadata`: [`Metadata`](@ref) object. As for `dims`.
+- `metadata`: `Metadata` object. As for `dims`.
 - `window`: Like `view` but lazy, for disk based data. Can be a tuple of Dimensions,
     selectors or regular indices. These will be applied when the data is loaded or indexed.
 """

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -294,7 +294,7 @@ A concrete `MemGeoStack` implementation. Holds layers of [`GeoArray`](@ref).
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
 - `refdims`: Reference dimensions from earlier subsetting.
-- `metadata`: Metadata as a `DimensionalData.AbstractStackMetadata` object.
+- `metadata`: A `DimensionalData.Metadata` object.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.
 """
@@ -344,7 +344,7 @@ Concrete [`DiskGeoStack`](@ref) implementation. Loads a stack of files lazily fr
 - `keys`: Used as stack keys when a `Tuple`, `Vector` or splat of filenames are passed in.
 - `window`: A `Tuple` of `Dimension`/`Selector`/indices that will be applied to the
     contained arrays when they are accessed.
-- `metadata`: Metadata as a `DimensionalData.StackMetadata` object.
+- `metadata`: A `DimensionalData.Metadata` object.
 - `childtype`: The type of the child data. eg. `GDALarray`. Required.
 - `childkwargs`: A `NamedTuple` of keyword arguments to pass to the `childtype` constructor.
 - `refdims`: `Tuple` of  position `Dimension` the array was sliced from.

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -36,7 +36,7 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
     @testset "other fields" begin
         # This file has an inorrect missing value
         @test missingval(gdalarray) == nothing
-        @test metadata(gdalarray) isa GDALarrayMetadata
+        @test metadata(gdalarray) isa Metadata{:GDAL}
         @test basename(metadata(gdalarray).val[:filepath]) == "cea.tif"
         @test name(gdalarray) == :test
         @test label(gdalarray) == "test"

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -84,6 +84,7 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
         @test refdims(geoA) isa Tuple{<:Band} 
         @test metadata(geoA) == metadata(gdalarray)
         @test missingval(geoA) == nothing
+        @test name(geoA) == :test
     end
 
     @testset "save" begin
@@ -168,8 +169,8 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
        
         # This needs netcdf bounds variables to work
         @testset "to netcdf" begin
-            filename2 = tempname()
-            write(filename2, NCDarray, gdalarray[Band(1)])
+            filename2 = tempname() * ".nc"
+            write(filename2, gdalarray[Band(1)])
             saved = GeoArray(NCDarray(filename2; crs=crs(gdalarray)))
             @test size(saved) == size(gdalarray[Band(1)])
             @test saved ≈ reverse(gdalarray[Band(1)]; dims=Lat)

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -1,6 +1,7 @@
 using GeoData, Test, Statistics, Dates, Plots
 import NCDatasets, ArchGDAL
 using GeoData: name, mode, window, DiskStack, bounds
+
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
 const DD = DimensionalData
@@ -33,7 +34,7 @@ path = stem * ".gri"
 
     @testset "other fields" begin
         @test missingval(grdarray) == -3.4f38
-        @test metadata(grdarray) isa GRDarrayMetadata
+        @test metadata(grdarray) isa Metadata{:GRD}
         @test name(grdarray) == Symbol("red:green:blue")
         @test label(grdarray) == "red:green:blue"
         @test units(grdarray) == nothing
@@ -79,7 +80,6 @@ path = stem * ".gri"
     # end
 
     @testset "selectors" begin
-<<<<<<< HEAD
         geoA = grdarray[Y(Contains(3)), X(:), Band(1)]
         @test geoA isa GeoArray{Float32,1}
         @test grdarray[X(Contains(20)), Y(Contains(10)), Band(1)] isa Float32
@@ -91,19 +91,6 @@ path = stem * ".gri"
         @test eltype(geoA) <: Float32
         @time geoA isa GeoArray{Float32,1}
         @test dims(geoA) isa Tuple{<:X,Y}
-=======
-        geoA = grdarray[Lat(Contains(3)), Lon(:), Band(1)]
-        @test geoA isa GeoArray{Float32,1}
-        @test grdarray[Lon(Contains(20)), Lat(Contains(10)), Band(1)] isa Float32
-    end
-
-    @testset "conversion to GeoArray" begin
-        geoA = grdarray[Lon(1:50), Lat(1:1), Band(1)]
-        @test size(geoA) == (50, 1)
-        @test eltype(geoA) <: Float32
-        @time geoA isa GeoArray{Float32,1}
-        @test dims(geoA) isa Tuple{<:Lon,Lat}
->>>>>>> bf3edfc (add convenience methods and test)
         @test refdims(geoA) isa Tuple{<:Band}
         @test metadata(geoA) == metadata(grdarray)
         @test missingval(geoA) == -3.4f38

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -79,6 +79,7 @@ path = stem * ".gri"
     # end
 
     @testset "selectors" begin
+<<<<<<< HEAD
         geoA = grdarray[Y(Contains(3)), X(:), Band(1)]
         @test geoA isa GeoArray{Float32,1}
         @test grdarray[X(Contains(20)), Y(Contains(10)), Band(1)] isa Float32
@@ -90,6 +91,19 @@ path = stem * ".gri"
         @test eltype(geoA) <: Float32
         @time geoA isa GeoArray{Float32,1}
         @test dims(geoA) isa Tuple{<:X,Y}
+=======
+        geoA = grdarray[Lat(Contains(3)), Lon(:), Band(1)]
+        @test geoA isa GeoArray{Float32,1}
+        @test grdarray[Lon(Contains(20)), Lat(Contains(10)), Band(1)] isa Float32
+    end
+
+    @testset "conversion to GeoArray" begin
+        geoA = grdarray[Lon(1:50), Lat(1:1), Band(1)]
+        @test size(geoA) == (50, 1)
+        @test eltype(geoA) <: Float32
+        @time geoA isa GeoArray{Float32,1}
+        @test dims(geoA) isa Tuple{<:Lon,Lat}
+>>>>>>> bf3edfc (add convenience methods and test)
         @test refdims(geoA) isa Tuple{<:Band}
         @test metadata(geoA) == metadata(grdarray)
         @test missingval(geoA) == -3.4f38

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -164,6 +164,7 @@ stackkeys = (
             @test all(val.(dims(saved)) .== val.(dims(geoA)))
             @test all(data(saved) .=== data(geoA))
             @test saved isa typeof(geoA)
+            # TODO test crs
         end
         @testset "to gdal" begin
             gdalfilename = tempname() * ".tif"

--- a/test/sources/ncdatasets.jl
+++ b/test/sources/ncdatasets.jl
@@ -68,7 +68,7 @@ stackkeys = (
 
     @testset "other fields" begin
         @test ismissing(missingval(ncarray))
-        @test metadata(ncarray) isa NCDarrayMetadata
+        @test metadata(ncarray) isa Metadata{:NCD}
         @test name(ncarray) == :tos
     end
 
@@ -216,7 +216,7 @@ end
     @testset "load ncstack" begin
         @test ncstack isa NCDstack{String}
         @test ismissing(missingval(ncstack))
-        @test metadata(ncstack) isa NCDstackMetadata
+        @test metadata(ncstack) isa Metadata{:NCD}
         @test refdims(ncstack) == ()
         # Loads child as a regular GeoArray
         @test_throws NCDatasets.NetCDFError ncstack[:not_a_key]
@@ -227,9 +227,9 @@ end
         @test keys(ncstack) isa NTuple{131,Symbol}
         @test keys(ncstack) == stackkeys
         @test first(keys(ncstack)) == :abso4
-        @test metadata(ncstack) isa NCDstackMetadata
+        @test metadata(ncstack) isa Metadata{:NCD}
         @test metadata(ncstack)["institution"] == "Max-Planck-Institute for Meteorology"
-        @test metadata(ncstack, :albedo) isa NCDarrayMetadata
+        @test metadata(ncstack, :albedo) isa Metadata{:NCD}
         @test metadata(ncstack, :albedo)["long_name"] == "surface albedo"
         # Test some DimensionalData.jl tools work
         # Time dim should be reduced to length 1 by mean

--- a/test/sources/smap.jl
+++ b/test/sources/smap.jl
@@ -1,6 +1,7 @@
 using GeoData, Test, Statistics, Dates
 import ArchGDAL, NCDatasets, HDF5
 using GeoData: Time, window, name
+
 testpath = joinpath(dirname(pathof(GeoData)), "../test/")
 include(joinpath(testpath, "test_utils.jl"))
 
@@ -29,7 +30,7 @@ if isfile(path1) && isfile(path2)
             @test refdims(smapstack) ==
                 (Ti(dt:step_:dt; mode=Sampled(Ordered(), Regular(step_), Intervals(Start()))),)
             # Currently empty
-            @test metadata(smaparray) isa SMAPstackMetadata
+            @test metadata(smaparray) isa Metadata{:SMAP}
         end
 
         @testset "conversion to GeoStack" begin


### PR DESCRIPTION
This PR deletes heaps of unnecesary code for labelling metadata. Now its all `Metadata{:name}`, with the same effect of tracking where it came from for when you go to save it.