### PR TITLE
Fix nodata type

### DIFF
--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -248,11 +248,16 @@ function missingval(raster::AG.RasterDataset, args...)
     # We can only handle data where all bands have the same missingval
     band = AG.getband(raster.ds, 1)
     nodata = AG.getnodatavalue(band)
-    if nodata isa Nothing
-        return nothing
+    return if nodata isa Nothing
+        nothing
     else
-        # Convert in case getnodatavalue is the wrong type
-        return convert(eltype(band), AG.getnodatavalue(band))
+        # Convert in case getnodatavalue is the wrong type.
+        # This conversion should always be safe.
+        if eltype(band) <: AbstractFloat && nodata isa Real
+            convert(eltype(band), nodata)
+        else
+            nodata
+        end
     end
 end
 

--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -247,7 +247,13 @@ end
 function missingval(raster::AG.RasterDataset, args...)
     # We can only handle data where all bands have the same missingval
     band = AG.getband(raster.ds, 1)
-    AG.getnodatavalue(band)
+    nodata = AG.getnodatavalue(band)
+    if nodata isa Nothing
+        return nothing
+    else
+        # Convert in case getnodatavalue is the wrong type
+        return convert(eltype(band), AG.getnodatavalue(band))
+    end
 end
 
 # metadata(raster::RasterDataset, key) = begin

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -1,4 +1,4 @@
-using GeoData, Test, Statistics, Dates, Plots, DimensionalData
+using GeoData, Test, Statistics, Dates, Plots, DimensionalData, RasterDataSources
 import ArchGDAL, NCDatasets
 using GeoData: window, mode, span, sampling, name, bounds
 
@@ -209,6 +209,12 @@ path = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea.tif
     @testset "plot" begin # TODO write some tests for this
         gdalarray |> plot
         gdalarray[Y(1)] |> plot
+    end
+
+    @testset "nodatavalue type matches the array type" begin
+        A = geoarray(WorldClim{Climate}, :tavg; res="10m", month=1)
+        @test typeof(missingval(A)) === eltype(A)
+        @test missingval(A) === -3.4f38
     end
 
 end


### PR DESCRIPTION
GDAL can return `Float64` for the nodataval when the grid is `Float32`. This means they may not be equal values with `==`. To avoid needing `isapprox` we can eagerly convert the float type, which usually fixes the problem.