### PR TITLE
Bugfix series child

### DIFF
--- a/src/series.jl
+++ b/src/series.jl
@@ -105,24 +105,28 @@ function GeoSeries(data, dims; refdims=(), childtype, childkwargs=())
 end
 
 @inline function DD.rebuild(
-    A::GeoSeries, data, dims::Tuple, refdims, childtype=childtype(A), childkwargs=childkwargs(A)
+    A::GeoSeries, data, dims::Tuple, refdims, name=name(A), childtype=childtype(A), childkwargs=childkwargs(A)
 )
     ct = _choosechildtype(data, childtype)
     GeoSeries(data, dims, refdims, ct, childkwargs)
 end
 @inline function DD.rebuild(
     A::GeoSeries; 
-    data=data(A), dims=dims(A), refdims=refdims(A), childtype=childtype(A), childkwargs=childkwargs(A)
+    data=data(A), dims=dims(A), refdims=refdims(A), name=nothing, childtype=childtype(A), childkwargs=childkwargs(A)
 )
     ct = _choosechildtype(data, childtype)
     GeoSeries(data, dims, refdims, ct, childkwargs)
 end
 
 function _choosechildtype(data, childtype)
-    ct = if data isa String || first(data) isa String 
+    ct = if data isa AbstractString 
         childtype(A)
-    else
+    elseif data isa AbstractVector{<:AbstractString}
+        childtype(A)
+    elseif length(data) > 0
         DD.basetypeof(first(data))
+    else
+        Nothing
     end
 end
 

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -224,7 +224,6 @@ end
 
     @testset "read" begin
         st = read(gdalstack)
-        display(st)
         @test st isa GeoStack
         @test st.data isa NamedTuple
         @test first(st.data) isa GeoArray


### PR DESCRIPTION
Getting the series child type was breaking both because `name` wasn't used in `rebuild`, and because `first` was used on a series vector, even if is empty.
