### PR TITLE
use typemin to write missing missingval in gdal and grd

### DIFF
--- a/src/sources/gdal.jl
+++ b/src/sources/gdal.jl
@@ -251,6 +251,7 @@ end
 function _gdalwrite(filename, A::AbstractGeoArray, nbands; 
     driver=AG.extensiondriver(filename), compress="DEFLATE", chunk=nothing
 )
+    A = maybe_typemin_as_missingval(filename, A)
     kw = (width=size(A, X()), height=size(A, Y()), nbands=nbands, dtype=eltype(A))
     gdaldriver = AG.getdriver(driver)
     if driver == "GTiff" 

--- a/src/sources/grd.jl
+++ b/src/sources/grd.jl
@@ -149,6 +149,7 @@ The extension of `filename` will be ignored.
 Returns `filename`.
 """
 function Base.write(filename::String, ::Type{GRDfile}, A::AbstractGeoArray)
+    A = maybe_typemin_as_missingval(filename, A)
     if hasdim(A, Band)
         correctedA = permutedims(A, (X, Y, Band)) |>
             a -> reorder(a, GRD_INDEX_ORDER) |>

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,6 +21,17 @@ function noindex_to_sampled(dims::DimTuple)
     end
 end
 
+function maybe_typemin_as_missingval(filename::String, A::AbstractGeoArray{T}) where T
+    if ismissing(missingval(A))
+        newmissingval = typemin(Missings.nonmissingtype(T)) 
+        ext = splitext(filename)
+        @warn "`missing` cant be written to $ext, typemin of $newmissingval used instead" 
+        replace_missing(A, newmissingval)
+    else
+        A
+    end
+end
+
 # We often need to convert the locus and the mode in the same step,
 # as doing it in the wrong order can give errors.
 # function convert_locus_mode(M1::Type{<:IndexMode}, L1::Type{<:Locus}, dim::Dimension)

--- a/test/sources/gdal.jl
+++ b/test/sources/gdal.jl
@@ -290,6 +290,14 @@ gdalpath = maybedownload("https://download.osgeo.org/geotiff/samples/gdal_eg/cea
             @test all(map((a, b) -> isapprox(a, b; rtol=1e-6), projectedbounds(saved, Y),  projectedbounds(gdalarray, Y)))
         end
 
+        @testset "write missing" begin
+            A = replace_missing(gdalarray, missing)
+            filename = tempname() * ".tif"
+            write(filename, A)
+            @test missingval(GeoArray(filename)) === typemin(UInt8)
+            rm(filename)
+        end
+
     end
 
     @testset "show" begin

--- a/test/sources/grd.jl
+++ b/test/sources/grd.jl
@@ -229,6 +229,14 @@ path = stem * ".gri"
             @test val(dims(gdalarray2, Band)) == 1:3
         end
 
+        @testset "write missing" begin
+            A = replace_missing(grdarray, missing)
+            filename = tempname() * ".grd"
+            write(filename, A)
+            @test missingval(GeoArray(filename)) === typemin(Float32)
+            rm(filename)
+        end
+
     end
 
     @testset "show" begin


### PR DESCRIPTION
We should be able to just save `GeoArray` to tif/grd even if the contain `missing` values. This PR replaces `missing` with `typemin(eltype(A))` before saving with GDAL or to grd.