### PR TITLE
Rename to Rasters.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
-name = "GeoData"
-uuid = "9b6fcbb8-86d6-11e9-1ce7-23a6bb139a78"
+name = "Rasters"
+uuid = "a3a2b9e3-a471-40c9-b274-f788e487c689"
 authors = ["Rafael Schouten <rafaelschouten@gmail.com>"]
 version = "0.6.1"
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ multi-layered stacks, and multi-file series of arrays and stacks.
 
 ![EarthEnv HabitatHeterogeneity layers trimmed to Australia](https://rafaqz.github.io/GeoData.jl/stable/trim_example_after.png)
 
-_A GeoStack of EarthEnv HabitatHeterogeneity layers, trimmed to Australia and plotted with Plots.jl_
+_A RasterStack of EarthEnv HabitatHeterogeneity layers, trimmed to Australia and plotted with Plots.jl_
 
 
 ## Lazyness
 
 - Data is loaded lazily wherever possible using
   [DiskArrays.jl](https://github.com/meggart/DiskArrays.jl). Indexing a
-  `GeoStack` by name is always lazy, while `view` of a `GeoArray` is lazy and
+  `RasterStack` by name is always lazy, while `view` of a `Raster` is lazy and
   `getindex` will load to memory. `read` can be used on any object to ensure
   that all data is loaded to memory.
 - Broadcast over disk-based objects is lazy - it will only run when the array is
@@ -33,12 +33,12 @@ _A GeoStack of EarthEnv HabitatHeterogeneity layers, trimmed to Australia and pl
 GeoData provides a standardised interface that allows many source data types to
 be used with identical syntax.
 
-- Scripts and packages building on GeoData.jl can treat `AbstractGeoArray`,
-  `AbstractGeoStack`, and `AbstrackGeoSeries` as black boxes.
+- Scripts and packages building on GeoData.jl can treat `AbstractRaster`,
+  `AbstractRasterStack`, and `AbstrackRasterSeries` as black boxes.
   - The data could hold GeoTiff or NetCDF files, `Array`s in memory or
     `CuArray`s on the GPU - they will all behave in the same way.
-  - `AbstractGeoStack` can be a Netcdf or HDF5 file, or a `NamedTuple` of
-    `GDALarray` holding `.tif` files, or all `GeoArray` in memory.
+  - `AbstractRasterStack` can be a Netcdf or HDF5 file, or a `NamedTuple` of
+    `GDALarray` holding `.tif` files, or all `Raster` in memory.
   - Users do not have to deal with the specifics of spatial file types.
 - For `Projected` mode you can index with any projection by setting the
   `mappedcrs` keyword on construction. You don't need to know the underlying

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,16 +1,16 @@
-using Documenter, GeoData, Plots, Logging, Statistics, Dates
+using Documenter, Rasters, Plots, Logging, Statistics, Dates
 
-using GeoData.LookupArrays, GeoData.Dimensions
+using Rasters.LookupArrays, Rasters.Dimensions
 
 ENV["GKSwstype"] = "100"
 
 # Plots warnings are brWarn doctests. They dont warn the second time.
 # Downloads also show op in doctests. So download everything first.
 function flush_info_and_warnings()
-    # GeoStack(AWAP, (:tmin, :tmax); date=DateTime(2001, 1, 1))
-    # GeoStack(EarthEnv{HabitatHeterogeneity}, (:evenness, :range, :contrast, :correlation))
-    # GeoStack(WorldClim{BioClim}, (1, 3, 5, 7, 12))
-    st = GeoStack(WorldClim{Climate}; month=1);
+    # RasterStack(AWAP, (:tmin, :tmax); date=DateTime(2001, 1, 1))
+    # RasterStack(EarthEnv{HabitatHeterogeneity}, (:evenness, :range, :contrast, :correlation))
+    # RasterStack(WorldClim{BioClim}, (1, 3, 5, 7, 12))
+    st = RasterStack(WorldClim{Climate}; month=1);
     plot(st)
 end
 flush_info_and_warnings()
@@ -20,8 +20,8 @@ Logging.disable_logging(Logging.Warn)
 
 # Make the docs, without running the tests again
 makedocs(
-    modules = [GeoData],
-    sitename = "GeoData.jl",
+    modules = [Rasters],
+    sitename = "Rasters.jl",
     strict = true,
     clean = false,
 )
@@ -30,5 +30,5 @@ makedocs(
 Logging.disable_logging(Logging.BelowMinLevel)
 
 deploydocs(
-    repo = "github.com/rafaqz/GeoData.jl.git",
+    repo = "github.com/rafaqz/Rasters.jl.git",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# GeoData.jl
+# Rasters.jl
 
 ```@docs
 GeoData
@@ -27,7 +27,7 @@ Use the `Between` selector to take a `view` of madagascar:
 
 ```@example
 using GeoData, Plots
-A = GeoArray(WorldClim{BioClim}, 5)
+A = Raster(WorldClim{BioClim}, 5)
 madagascar = view(A, X(Between(43.25, 50.48)), Y(Between(-25.61, -12.04))) 
 plot(madagascar)
 ```
@@ -56,7 +56,7 @@ Note that most regular Julia methods, such as `replace`, work as for a standard
 |                           |                                                                              |
 | :------------------------ | :--------------------------------------------------------------------------- |
 | [`classify`](@ref)        | classify values into categories.                                             |
-| [`mask`](@ref)            | mask and object by a polygon or `GeoArray` along `X/Y`, or other dimensions. |
+| [`mask`](@ref)            | mask and object by a polygon or `Raster` along `X/Y`, or other dimensions. |
 | [`replace_missing`](@ref) | replace all missing values in an object and update `missingval`.             |
 
 
@@ -92,7 +92,7 @@ mean(A, dims=Ti)
 ```
 
 `broadcast` works lazily from disk, and is only applied when data is directly
-indexed. Adding a dot to any function will use broadcast over a `GeoArray`. 
+indexed. Adding a dot to any function will use broadcast over a `Raster`. 
 
 ### Broadcasting
 
@@ -106,12 +106,12 @@ A .*= 2
 To broadcast directly to disk, we need to open the file in write mode:
 
 ```julia
-open(GeoArray(filename); write=true) do O
+open(Raster(filename); write=true) do O
     O .*= 2
 end
 ```
 
-To broadcast over a `GeoStack` use `map`, which applies a function to the layers
+To broadcast over a `RasterStack` use `map`, which applies a function to the layers
 of the stack - here `A`.
 
 ```julia
@@ -165,7 +165,7 @@ object to any `GeoFormat` from GeoFormatTypes.jl.
 ## Examples and Plotting
 
 [Plots.jl](https://github.com/JuliaPlots/Plots.jl) is fully supported by
-GeoData.jl, with recipes for plotting `GeoArray` and `GeoStack` provided. `plot`
+GeoData.jl, with recipes for plotting `Raster` and `RasterStack` provided. `plot`
 will plot a heatmap with axes matching dimension values. If `mappedcrs` is used,
 converted values will be shown on axes instead of the underlying `crs` values.
 `contourf` will similarly plot a filled contour plot.
@@ -176,7 +176,7 @@ It can be set manually to change the resolution (e.g. for large or high-quality 
 
 ```julia
 using GeoData, Plots
-A = GeoArray(WorldClim{BioClim}, 5)
+A = Raster(WorldClim{BioClim}, 5)
 plot(A; max_res=3000)
 ```
 
@@ -184,14 +184,14 @@ plot(A; max_res=3000)
 
 Our first example simply loads a file from disk and plots it.
 
-This netcdf file only has one layer, if it has more we could use `GeoStack`
+This netcdf file only has one layer, if it has more we could use `RasterStack`
 instead. 
 
 ```@example nc
 using GeoData, Plots
 url = "https://www.unidata.ucar.edu/software/netcdf/examples/tos_O1_2001-2002.nc";
 filename = download(url, "tos_O1_2001-2002.nc");
-A = GeoArray(filename)
+A = Raster(filename)
 ```
 
 Objects with Dimensions other than `X` an `Y` will produce multi-pane plots.
@@ -273,7 +273,7 @@ coords = map(r -> (r.longitude, r.latitude), records)
 Get BioClim layers and subset to south-east australia
 
 ```@example sdm
-A = GeoStack(WorldClim{BioClim}, (1, 3, 7, 12))
+A = RasterStack(WorldClim{BioClim}, (1, 3, 7, 12))
 SE_aus = A[X=Between(138, 155), Y=Between(-40, -25), Band=1]
 ```
 
@@ -327,7 +327,7 @@ Then load raster data. We load some worldclim layers using RasterDataSources via
 GeoData.jl, and drop the Band dimension.
 
 ```@example mask
-climate = GeoStack(WorldClim{Climate}, (:tmin, :tmax, :prec, :wind); month=July)[Band(1)]
+climate = RasterStack(WorldClim{Climate}, (:tmin, :tmax, :prec, :wind); month=July)[Band(1)]
 ```
 
 `mask` denmark, norway and sweden from the global dataset using their border polygon,
@@ -412,43 +412,43 @@ write("scandinavia.tif", scandinavia)
 GeoData.jl provides a range of other methods that are being added to over time.
 Where applicable these methods read and write lazily to and from disk-based
 arrays of common raster file types. These methods also work for entire
-`GeoStacks` and `GeoSeries` using the same syntax.
+`RasterStacks` and `RasterSeries` using the same syntax.
 
 ## Objects
 
-### GeoArray
+### Raster
 
-Spatial raster data is essentially just an `Array`. But `GeoArray` wrappers
+Spatial raster data is essentially just an `Array`. But `Raster` wrappers
 allow treating them as an array that maintains its spatial index, crs and other
 metadata through all transformations. This means the can always be plotted and
 written to disk after applying most base Julia methods, and most `broadcast`s.
 
 ```@docs
-AbstractGeoArray
-GeoArray
-GeoArray(T::Type{<:RasterDataSources.RasterDataSource}, layer)
+AbstractRaster
+Raster
+Raster(T::Type{<:RasterDataSources.RasterDataSource}, layer)
 ```
 
-### GeoStack
+### RasterStack
 
 Spatial data often comes as a bundle of multiple named arrays, as in netcdf.
-`GeoStack` can represent this, or multiple files organised in a similar way.
+`RasterStack` can represent this, or multiple files organised in a similar way.
 
 ```@docs
-AbstractGeoStack
-GeoStack
-GeoStack(T::Type{<:RasterDataSources.RasterDataSource})
+AbstractRasterStack
+RasterStack
+RasterStack(T::Type{<:RasterDataSources.RasterDataSource})
 ```
 
-### GeoSeries
+### RasterSeries
 
 A series is an meta-array that holds other files/data that is distributed over
-some dimension, often time. These files/data can be `GeoArray`s or `GeoStack`s.
+some dimension, often time. These files/data can be `Raster`s or `RasterStack`s.
 
 ```@docs
-AbstractGeoSeries
-GeoSeries
-GeoSeries(T::Type{<:RasterDataSources.RasterDataSource})
+AbstractRasterSeries
+RasterSeries
+RasterSeries(T::Type{<:RasterDataSources.RasterDataSource})
 ```
 
 ### Dimensions
@@ -480,8 +480,8 @@ Mapped
 
 ## Data sources
 
-GeoData.jl uses a number of backends to load raster data. `GeoArray`, `GeoStack`
-and `GeoSeries` will detect which backend to use for you, automatically.
+GeoData.jl uses a number of backends to load raster data. `Raster`, `RasterStack`
+and `RasterSeries` will detect which backend to use for you, automatically.
 
 ### GRD
 
@@ -493,8 +493,8 @@ very fast, but are not compressed. They are always 3 dimensional, and have `Y`,
 
 NetCDF `.nc` files are loaded using
 [NCDatasets.jl](https://github.com/Alexander-Barth/NCDatasets.jl). Layers from
-files can be loaded as `GeoArray("filename.nc"; key=:layername)`. Without `key`
-the first layer is used. `GeoStack("filename.nc")` will use all netcdf variables
+files can be loaded as `Raster("filename.nc"; key=:layername)`. Without `key`
+the first layer is used. `RasterStack("filename.nc")` will use all netcdf variables
 in the file that are not dimensions as layers. 
 
 NetCDF layers can have arbitrary dimensions. Known, common dimension names are
@@ -505,8 +505,8 @@ in the same file may also have different dimensions.
 
 All files GDAL can access, such as `.tiff` and `.asc` files, can be loaded,
 using [ArchGDAL.jl](https://github.com/yeesian/ArchGDAL.jl/issues). These are
-generally best loaded as `GeoArray("filename.tif")`, but can be loaded as
-`GeoStack("filename.tif"; layersfrom=Band)`, taking layers from the `Band`
+generally best loaded as `Raster("filename.tif")`, but can be loaded as
+`RasterStack("filename.tif"; layersfrom=Band)`, taking layers from the `Band`
 dimension, which is also the default.
 
 ### SMAP
@@ -515,8 +515,8 @@ The [Soil Moisture Active-Passive](https://smap.jpl.nasa.gov/) dataset provides
 global layers of soil moisture, temperature and other related data, in a custom
 HDF5 format. Layers are always 2 dimensional, with `Y` and `X` dimensions.
 
-These can be loaded as multi-layered `GeoStack("filename.h5")`. Individual
-layers can be loaded as `GeoArray("filename.h5"; key=:layerkey)`, without `key`
+These can be loaded as multi-layered `RasterStack("filename.h5")`. Individual
+layers can be loaded as `Raster("filename.h5"; key=:layerkey)`, without `key`
 the first layer is used.
 
 ```@docs
@@ -539,15 +539,15 @@ metadata conversion has not been completely implemented.
 standardises the download of common raster data sources, with a focus on
 datasets used in ecology and the environmental sciences. RasterDataSources.jl is
 tightly integrated into GeoData.jl, so that datsets and keywords can be used
-directly to download and load data as a `GeoArray`, `GeoStack`, or `GeoSeries`.
+directly to download and load data as a `Raster`, `RasterStack`, or `RasterSeries`.
 
 ```@example
 using GeoData, Plots, Dates
-A = GeoArray(WorldClim{Climate}, :tavg; month=June)
+A = Raster(WorldClim{Climate}, :tavg; month=June)
 plot(A)
 ```
 
-See the docs for [`GeoArray`](@ref), [`GeoStack`](@ref) and [`GeoSeries`](@ref),
+See the docs for [`Raster`](@ref), [`RasterStack`](@ref) and [`RasterSeries`](@ref),
 and the docs for `RasterDataSources.getraster` for syntax to specify various
 data sources.
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,7 @@
 # Rasters.jl
 
 ```@docs
-GeoData
+Rasters
 ```
 
 ## Common Applications
@@ -26,7 +26,7 @@ e.g. certain X/Y coordinates. The available selectors are listed here:
 Use the `Between` selector to take a `view` of madagascar:
 
 ```@example
-using GeoData, Plots
+using Rasters, Plots
 A = Raster(WorldClim{BioClim}, 5)
 madagascar = view(A, X(Between(43.25, 50.48)), Y(Between(-25.61, -12.04))) 
 plot(madagascar)
@@ -165,7 +165,7 @@ object to any `GeoFormat` from GeoFormatTypes.jl.
 ## Examples and Plotting
 
 [Plots.jl](https://github.com/JuliaPlots/Plots.jl) is fully supported by
-GeoData.jl, with recipes for plotting `Raster` and `RasterStack` provided. `plot`
+Rasters.jl, with recipes for plotting `Raster` and `RasterStack` provided. `plot`
 will plot a heatmap with axes matching dimension values. If `mappedcrs` is used,
 converted values will be shown on axes instead of the underlying `crs` values.
 `contourf` will similarly plot a filled contour plot.
@@ -175,7 +175,7 @@ specifies the maximum pixel resolution to show on the longest axis of the array.
 It can be set manually to change the resolution (e.g. for large or high-quality plots):
 
 ```julia
-using GeoData, Plots
+using Rasters, Plots
 A = Raster(WorldClim{BioClim}, 5)
 plot(A; max_res=3000)
 ```
@@ -188,7 +188,7 @@ This netcdf file only has one layer, if it has more we could use `RasterStack`
 instead. 
 
 ```@example nc
-using GeoData, Plots
+using Rasters, Plots
 url = "https://www.unidata.ucar.edu/software/netcdf/examples/tos_O1_2001-2002.nc";
 filename = download(url, "tos_O1_2001-2002.nc");
 A = Raster(filename)
@@ -238,7 +238,7 @@ Write the mean values to disk
 write("mean_tos.nc", mean_tos)
 ```
 
-Plotting recipes in DimensionalData.jl are the fallback for GeoData.jl when the
+Plotting recipes in DimensionalData.jl are the fallback for Rasters.jl when the
 object doesn't have 2 `X`/`Y`/`Z` dimensions, or a non-spatial plot command is
 used. So (as a random example) we could plot a transect of ocean surface
 temperature at 20 degree latitude :
@@ -253,7 +253,7 @@ A[Y(Near(20.0)), Ti(1)] |> plot
 Load occurrences for the Mountain Pygmy Possum using GBIF.jl
 
 ```@example sdm
-using GeoData, GBIF, Plots 
+using Rasters, GBIF, Plots 
 records = GBIF.occurrences("scientificName" => "Burramys parvus", "limit" => 300)
 
 # Get the rest of the occurrences, we need to do this manually with a loop.
@@ -309,7 +309,7 @@ then `mosaic` together to make a single plot.
 First, get the country boundary shape files using GADM.jl.
 
 ```@example mask
-using GeoData, Shapefile, Plots, Dates, Downloads
+using Rasters, Shapefile, Plots, Dates, Downloads
 
 # Download the shapefile
 shapefile_url = "https://github.com/nvkelso/natural-earth-vector/raw/master/10m_cultural/ne_10m_admin_0_countries.shp"
@@ -324,7 +324,7 @@ sweden_border = shapes.shapes[55]
 ```
 
 Then load raster data. We load some worldclim layers using RasterDataSources via
-GeoData.jl, and drop the Band dimension.
+Rasters.jl, and drop the Band dimension.
 
 ```@example mask
 climate = RasterStack(WorldClim{Climate}, (:tmin, :tmax, :prec, :wind); month=July)[Band(1)]
@@ -409,7 +409,7 @@ write("scandinavia.nc", scandinavia)
 write("scandinavia.tif", scandinavia)
 ```
 
-GeoData.jl provides a range of other methods that are being added to over time.
+Rasters.jl provides a range of other methods that are being added to over time.
 Where applicable these methods read and write lazily to and from disk-based
 arrays of common raster file types. These methods also work for entire
 `RasterStacks` and `RasterSeries` using the same syntax.
@@ -453,7 +453,7 @@ RasterSeries(T::Type{<:RasterDataSources.RasterDataSource})
 
 ### Dimensions
 
-GeoData uses `X`, `Y`, and `Z` dimensions from DimensionalData.jl to represent
+Rasters uses `X`, `Y`, and `Z` dimensions from DimensionalData.jl to represent
 spatial directions like longitude, latitude and the vertical dimension, and
 subset data with them. `Ti` is used for time, and `Band` represent bands. Other
 dimensions can have arbitrary names, but will be treated generically. See
@@ -467,20 +467,20 @@ Band
 ### Lookup Arrays
 
 These specify properties of the index associated with e.g. the X and Y
-dimension. GeoData.jl defines additional lookup arrays: [`Projected`](@ref) to handle
+dimension. Rasters.jl defines additional lookup arrays: [`Projected`](@ref) to handle
 dimensions with projections, and [`Mapped`](@ref) where the projection is mapped to
 another projection like `EPSG(4326)`. `Mapped` is largely designed to handle
 NetCDF dimensions, especially with `Explicit` spans.
 
 ```@docs
-GeoData.AbstractProjected
+Rasters.AbstractProjected
 Projected
 Mapped
 ```
 
 ## Data sources
 
-GeoData.jl uses a number of backends to load raster data. `Raster`, `RasterStack`
+Rasters.jl uses a number of backends to load raster data. `Raster`, `RasterStack`
 and `RasterSeries` will detect which backend to use for you, automatically.
 
 ### GRD
@@ -538,11 +538,11 @@ metadata conversion has not been completely implemented.
 [RasterDataSources.jl](https://github.com/EcoJulia/RasterDataSources.jl)
 standardises the download of common raster data sources, with a focus on
 datasets used in ecology and the environmental sciences. RasterDataSources.jl is
-tightly integrated into GeoData.jl, so that datsets and keywords can be used
+tightly integrated into Rasters.jl, so that datsets and keywords can be used
 directly to download and load data as a `Raster`, `RasterStack`, or `RasterSeries`.
 
 ```@example
-using GeoData, Plots, Dates
+using Rasters, Plots, Dates
 A = Raster(WorldClim{Climate}, :tavg; month=June)
 plot(A)
 ```
@@ -553,11 +553,11 @@ data sources.
 
 ## Exported functions
 
-GeoData.jl is a direct extension of DimensionalData.jl. See [DimensionalData.jl
+Rasters.jl is a direct extension of DimensionalData.jl. See [DimensionalData.jl
 docs](https://rafaqz.github.io/DimensionalData.jl/stable/) for the majority of
-types and functions that can be used in GeoData.jl.
+types and functions that can be used in Rasters.jl.
 
-Functions more specific to geospatial data are included in GeoData.jl, and
+Functions more specific to geospatial data are included in Rasters.jl, and
 listed below.
 
 ```@docs
@@ -599,7 +599,7 @@ warp
 
 ### File operations
 
-These Base and DimensionalData methods have specific GeoData.jl versions:
+These Base and DimensionalData methods have specific Rasters.jl versions:
 
 ```@docs
 modify
@@ -612,7 +612,7 @@ write
 ## Internals
 
 ```@docs
-GeoData.FileArray
-GeoData.FileStack
-GeoData.GeoDiskArray
+Rasters.FileArray
+Rasters.FileStack
+Rasters.RasterDiskArray
 ```

--- a/src/Rasters.jl
+++ b/src/Rasters.jl
@@ -1,11 +1,11 @@
-module GeoData
+module Rasters
 
 # Use the README as the module docs
 @doc let
     path = joinpath(dirname(@__DIR__), "README.md")
     include_dependency(path)
     read(path, String)
-end GeoData
+end Rasters
 
 using Dates
 
@@ -43,9 +43,9 @@ using Base: tail, @propagate_inbounds
 using Setfield: @set, @set!
 using ColorTypes: RGB
 
-export AbstractGeoArray, GeoArray
-export AbstractGeoStack, GeoStack
-export AbstractGeoSeries, GeoSeries
+export AbstractRaster, Raster
+export AbstractRasterStack, RasterStack
+export AbstractRasterSeries, RasterSeries
 export Projected, Mapped
 export Band
 export missingval, boolmask, missingmask, replace_missing,

--- a/src/filearray.jl
+++ b/src/filearray.jl
@@ -53,28 +53,28 @@ end
 
 
 """
-    GeoDiskArray <: DiskArrays.AbstractDiskArray
+    RasterDiskArray <: DiskArrays.AbstractDiskArray
 
 A basic DiskArrays.jl wrapper for objects that don't have one defined yet. 
-When we `open` a `FileArray` it is replaced with a `GeoDiskArray`.
+When we `open` a `FileArray` it is replaced with a `RasterDiskArray`.
 """
-struct GeoDiskArray{X,T,N,V,EC,HC} <: DiskArrays.AbstractDiskArray{T,N}
+struct RasterDiskArray{X,T,N,V,EC,HC} <: DiskArrays.AbstractDiskArray{T,N}
     var::V
     eachchunk::EC
     haschunks::HC
 end
-function GeoDiskArray{X}(
+function RasterDiskArray{X}(
     var::V, eachchunk=DA.eachchunk(var), haschunks=DA.haschunks(var)
 ) where {X,V}
     T = eltype(var)
     N = ndims(var)
-    GeoDiskArray{X,T,N,V,typeof(eachchunk),typeof(haschunks)}(var, eachchunk, haschunks)
+    RasterDiskArray{X,T,N,V,typeof(eachchunk),typeof(haschunks)}(var, eachchunk, haschunks)
 end
 
-Base.parent(A::GeoDiskArray) = A.var
-Base.size(A::GeoDiskArray{<:Any,T,N}) where {T,N} = size(parent(A))::NTuple{N,Int}
+Base.parent(A::RasterDiskArray) = A.var
+Base.size(A::RasterDiskArray{<:Any,T,N}) where {T,N} = size(parent(A))::NTuple{N,Int}
 
-DA.haschunks(A::GeoDiskArray) = A.haschunks
-DA.eachchunk(A::GeoDiskArray) = A.eachchunk
-DA.readblock!(A::GeoDiskArray, aout, r::AbstractUnitRange...) = aout .= parent(A)[r...]
-DA.writeblock!(A::GeoDiskArray, v, r::AbstractUnitRange...) = parent(A)[r...] .= v
+DA.haschunks(A::RasterDiskArray) = A.haschunks
+DA.eachchunk(A::RasterDiskArray) = A.eachchunk
+DA.readblock!(A::RasterDiskArray, aout, r::AbstractUnitRange...) = aout .= parent(A)[r...]
+DA.writeblock!(A::RasterDiskArray, v, r::AbstractUnitRange...) = parent(A)[r...] .= v

--- a/src/lookup.jl
+++ b/src/lookup.jl
@@ -185,7 +185,7 @@ end
 """
     setcrs(x, crs)
 
-Set the crs of a `GeoArray`, `GeoStack`, `Tuple` of `Dimension`,or a `Dimension`.
+Set the crs of a `Raster`, `RasterStack`, `Tuple` of `Dimension`,or a `Dimension`.
 """
 setcrs(A, crs) = set(A, setcrs(dims(A), crs)...)
 setcrs(dims::DimTuple, crs) = map(d -> setcrs(d, mappedcrs), dims)
@@ -195,7 +195,7 @@ setcrs(dim::LookupArray, crs) = rebuild(lookup(dim); crs)
 """
     setmappedcrs(x, crs)
 
-Set the mapped crs of a `GeoArray`, a `GeoStack`, a `Tuple`
+Set the mapped crs of a `Raster`, a `RasterStack`, a `Tuple`
 of `Dimension`, or a `Dimension`.
 """
 setmappedcrs(A, mappedcrs) = set(A, setmappedcrs(dims(A), mappedcrs)...)

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,11 +1,11 @@
 """
-    read(A::AbstractGeoArray)
-    read(A::AbstractGeoStack)
-    read(A::AbstractGeoSeries)
+    read(A::AbstractRaster)
+    read(A::AbstractRasterStack)
+    read(A::AbstractRasterSeries)
 
-`read` will move a GeoData.jl object completely to memory.
+`read` will move a Rasters.jl object completely to memory.
 """
-function Base.read(x::Union{AbstractGeoArray,AbstractGeoStack,AbstractGeoSeries})
+function Base.read(x::Union{AbstractRaster,AbstractRasterStack,AbstractRasterSeries})
     modify(x) do ds
         # Some backends don't implement `Array` properly.
         Array{eltype(ds),ndims(ds)}(undef, size(ds)) .= ds
@@ -13,45 +13,45 @@ function Base.read(x::Union{AbstractGeoArray,AbstractGeoStack,AbstractGeoSeries}
 end
 
 """
-    read!(src::Union{AbstractString,AbstractGeoArray}, dst::AbstractGeoArray)
-    read!(src::Union{AbstractString,AbstractGeoStack}, dst::AbstractGeoStack)
-    read!(scr::AbstractGeoSeries, dst::AbstractGeoSeries)
+    read!(src::Union{AbstractString,AbstractRaster}, dst::AbstractRaster)
+    read!(src::Union{AbstractString,AbstractRasterStack}, dst::AbstractRasterStack)
+    read!(scr::AbstractRasterSeries, dst::AbstractRasterSeries)
 
 `read!` will copy the data from `src` to the object `dst`. 
 
 `src` can be an object or a file-path `String`.
 """
-Base.read!(src::AbstractGeoArray, dst::AbstractArray) = dst .= src
-function Base.read!(src::AbstractGeoStack, dst::AbstractGeoStack)
+Base.read!(src::AbstractRaster, dst::AbstractArray) = dst .= src
+function Base.read!(src::AbstractRasterStack, dst::AbstractRasterStack)
     map(k -> read!(src[k], dst[k]), keys(dst))
     return dst
 end
-function Base.read!(src::AbstractGeoSeries, dst::AbstractGeoSeries)
+function Base.read!(src::AbstractRasterSeries, dst::AbstractRasterSeries)
     map(read!, src, dst)
     return dst
 end
 
 # Filename methods
-function Base.read!(filename::AbstractString, dst::AbstractGeoArray)
-    src = GeoArray(filename;
+function Base.read!(filename::AbstractString, dst::AbstractRaster)
+    src = Raster(filename;
         dims=dims(dst), refdims=refdims(dst), name=name(dst),
         metadata=metadata(dst), missingval=missingval(dst),
     )
     read!(src, dst)
 end
-function Base.read!(filenames::Union{NamedTuple,<:AbstractVector{<:AbstractString}}, dst::AbstractGeoStack)
+function Base.read!(filenames::Union{NamedTuple,<:AbstractVector{<:AbstractString}}, dst::AbstractRasterStack)
     _readstack!(filenames, dst)
 end
-function Base.read!(filenames::AbstractString, dst::AbstractGeoStack)
+function Base.read!(filenames::AbstractString, dst::AbstractRasterStack)
     _readstack!(filenames, dst)
 end
-function Base.read!(filenames::AbstractVector{<:Union{AbstractString,NamedTuple}}, dst::AbstractGeoSeries)
+function Base.read!(filenames::AbstractVector{<:Union{AbstractString,NamedTuple}}, dst::AbstractRasterSeries)
     map((fn, d) -> read!(fn, d), filenames, dst)
     return dst
 end
 
 function _readstack!(filenames, dst)
-    src = GeoStack(filenames;
+    src = RasterStack(filenames;
         dims=dims(dst), refdims=refdims(dst), keys=keys(dst), metadata=metadata(dst),
         layermetadata=DD.layermetadata(dst), layermissingval=layermissingval(dst),
     )

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,5 +1,5 @@
 
-function DD.show_after(io::IO, mime::MIME"text/plain", A::AbstractGeoArray)
+function DD.show_after(io::IO, mime::MIME"text/plain", A::AbstractRaster)
 
     if missingval(A) !== nothing
         printstyled(io, "with missingval: "; color=:light_black)
@@ -15,7 +15,7 @@ function DD.show_after(io::IO, mime::MIME"text/plain", A::AbstractGeoArray)
     end
 end
 
-function DD.show_after(io, mime, stack::AbstractGeoStack) 
+function DD.show_after(io, mime, stack::AbstractRasterStack) 
     if parent(stack) isa FileStack 
         printstyled(io, "\nfrom file:\n"; color=:light_black)
         println(io, filename(stack))
@@ -23,7 +23,7 @@ function DD.show_after(io, mime, stack::AbstractGeoStack)
 end
 
 # Stack types can be enourmous. Just use nameof(T)
-function Base.summary(io::IO, ser::AbstractGeoSeries{T,N}) where {T,N}
+function Base.summary(io::IO, ser::AbstractRasterSeries{T,N}) where {T,N}
     if N == 0  
         print(io, "0-dimensional ")
     elseif N == 1
@@ -34,7 +34,7 @@ function Base.summary(io::IO, ser::AbstractGeoSeries{T,N}) where {T,N}
     printstyled(io, string(nameof(typeof(ser)), "{$(nameof(T)),$N}"); color=:blue)
 end
 
-function Base.show(io::IO, mime::MIME"text/plain", A::AbstractGeoSeries{T,N}) where {T,N}
+function Base.show(io::IO, mime::MIME"text/plain", A::AbstractRasterSeries{T,N}) where {T,N}
     lines = 0
     summary(io, A)
     DD.print_name(io, name(A))

--- a/src/sources/rasterdatasources.jl
+++ b/src/sources/rasterdatasources.jl
@@ -5,10 +5,10 @@ using .RasterDataSources: RasterDataSource
 const RDS = RasterDataSources
 
 """
-    GeoArray(T::Type{<:RasterDataSource}, [layer]; kw...) => GeoArray
+    Raster(T::Type{<:RasterDataSource}, [layer]; kw...) => Raster
 
-Load a `RasterDataSource` as an `GeoArray`. `T` and `layers` are are passed to
-`RasterDataSources.getraster`, while `kw` args are for both `getraster` and `GeoArray`.
+Load a `RasterDataSource` as an `Raster`. `T` and `layers` are are passed to
+`RasterDataSources.getraster`, while `kw` args are for both `getraster` and `Raster`.
 
 # Keywords
 
@@ -16,23 +16,23 @@ Load a `RasterDataSource` as an `GeoArray`. `T` and `layers` are are passed to
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
 
-Other `GeoArray` keywords are passed to the `GeoArray` constructor.
+Other `Raster` keywords are passed to the `Raster` constructor.
 
 See the docs for 
 [`RasterDatasources.getraster`](http://docs.ecojulia.org/RasterDataSources.jl/stable/#getraster)
 for more specific details about data sources, layers and keyword arguments.
 """
-function GeoArray(T::Type{<:RasterDataSource}, layer; crs=_source_crs(T), kw...)
+function Raster(T::Type{<:RasterDataSource}, layer; crs=_source_crs(T), kw...)
     rds_kw, gd_kw = _filterkw(kw)
     filename = getraster(T, layer; rds_kw...)
-    GeoArray(filename; name=RDS.layerkeys(T, layer), crs, gd_kw...)
+    Raster(filename; name=RDS.layerkeys(T, layer), crs, gd_kw...)
 end
 
 """
-    GeoStack(T::Type{<:RasterDataSource}, [layers::Union{Symbol,AbstractArray,Tuple}]; kw...) => GeoStack
+    RasterStack(T::Type{<:RasterDataSource}, [layers::Union{Symbol,AbstractArray,Tuple}]; kw...) => RasterStack
 
-Load a `RasterDataSource` as an `GeoStack`. `T` and `layers` are passed to
-`RasterDataSources.getraster`, while `kw` args are for both `getraster` and `GeoStack`.
+Load a `RasterDataSource` as an `RasterStack`. `T` and `layers` are passed to
+`RasterDataSources.getraster`, while `kw` args are for both `getraster` and `RasterStack`.
 
 # Keywords
 
@@ -40,25 +40,25 @@ Load a `RasterDataSource` as an `GeoStack`. `T` and `layers` are passed to
 - `date`: a `DateTime` object, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
 
-Other `GeoStack` keywords are passed to the `GeoStack` constructor.
+Other `RasterStack` keywords are passed to the `RasterStack` constructor.
 
 See the docs for 
 [`RasterDatasources.getraster`](http://docs.ecojulia.org/RasterDataSources.jl/stable/#getraster)
 for more specific details about data sources, layers and keyword arguments.
 """
-GeoStack(T::Type{<:RasterDataSource}; kw...) = GeoStack(T, RDS.layers(T); kw...) 
-GeoStack(T::Type{<:RasterDataSource}, layer::Symbol; kw...) = GeoStack(T, (layer,); kw...) 
-function GeoStack(T::Type{<:RasterDataSource}, layers::Tuple; crs=_source_crs(T), kw...)
+RasterStack(T::Type{<:RasterDataSource}; kw...) = RasterStack(T, RDS.layers(T); kw...) 
+RasterStack(T::Type{<:RasterDataSource}, layer::Symbol; kw...) = RasterStack(T, (layer,); kw...) 
+function RasterStack(T::Type{<:RasterDataSource}, layers::Tuple; crs=_source_crs(T), kw...)
     rds_kw, gd_kw = _filterkw(kw)
     filenames = map(l -> getraster(T, l; rds_kw...), layers)
-    GeoStack(filenames; keys=RDS.layerkeys(T, layers), crs, gd_kw...)
+    RasterStack(filenames; keys=RDS.layerkeys(T, layers), crs, gd_kw...)
 end
 
 """
-    GeoSeries(T::Type{<:RasterDataSource}, [layers::Union{Symbol,AbstractArray,Tuple}]; kw...) => AbstractGeoSeries
+    RasterSeries(T::Type{<:RasterDataSource}, [layers::Union{Symbol,AbstractArray,Tuple}]; kw...) => AbstractRasterSeries
 
-Load a `RasterDataSource` as an `AbstractGeoSeries`. `T`, `args` are are passed to
-`RasterDataSource.getraster`, while `kw` args are for both `getraster` and `GeoSeries`.
+Load a `RasterDataSource` as an `AbstractRasterSeries`. `T`, `args` are are passed to
+`RasterDataSource.getraster`, while `kw` args are for both `getraster` and `RasterSeries`.
 
 # Keywords
 
@@ -66,15 +66,15 @@ Load a `RasterDataSource` as an `AbstractGeoSeries`. `T`, `args` are are passed 
 - `date`: a `Vector` of `DateTime` objects, usually for `Weather` datasets.
 - `res`: a `String` resolution, for datasets with multiple resolutions.
 
-Other `GeoSeries` keywords are passed to the `GeoSeries` constructor.
+Other `RasterSeries` keywords are passed to the `RasterSeries` constructor.
 
 See the docs for 
 [`RasterDatasources.getraster`](http://docs.ecojulia.org/RasterDataSources.jl/stable/#getraster)
 for more specific details about data sources, layers and keyword arguments.
 """
-GeoSeries(T::Type{<:RasterDataSource}; kw...) = GeoSeries(T, RDS.layers(T); kw...) 
+RasterSeries(T::Type{<:RasterDataSource}; kw...) = RasterSeries(T, RDS.layers(T); kw...) 
 # DateTime time-series
-function GeoSeries(T::Type{<:RasterDataSource}, layers; 
+function RasterSeries(T::Type{<:RasterDataSource}, layers; 
     resize=_mayberesize(T), crs=_source_crs(T), mappedcrs=nothing, kw...
 )
     monthdim = if haskey(values(kw), :month) values(kw)[:month] isa AbstractArray
@@ -95,18 +95,18 @@ function GeoSeries(T::Type{<:RasterDataSource}, layers;
         nothing
     end
     if isnothing(monthdim) && isnothing(datedim)
-        throw(ArgumentError("A GeoSeries can only be constructed from a data source with `date` or `month` keywords that are AbstractArray. For other sources, use GeoStack or GeoArray directly"))
+        throw(ArgumentError("A RasterSeries can only be constructed from a data source with `date` or `month` keywords that are AbstractArray. For other sources, use RasterStack or Raster directly"))
     end
 
     filenames = getraster(T, layers; kw...)
     can_duplicate = RDS.has_constant_dims(T) && RDS.has_constant_metadata(T)
 
     if filenames isa AbstractVector{<:AbstractVector}
-        series = [GeoSeries(inner_fns, monthdim; resize, crs, mappedcrs, duplicate_first=can_duplicate) for inner_fns in filenames]
-        return GeoSeries(series, datedim)
+        series = [RasterSeries(inner_fns, monthdim; resize, crs, mappedcrs, duplicate_first=can_duplicate) for inner_fns in filenames]
+        return RasterSeries(series, datedim)
     elseif filenames isa AbstractVector
         dim = isnothing(datedim) ? monthdim : datedim
-        return GeoSeries(filenames, dim; resize, crs, mappedcrs, duplicate_first=can_duplicate)
+        return RasterSeries(filenames, dim; resize, crs, mappedcrs, duplicate_first=can_duplicate)
     end
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -21,7 +21,7 @@ function noindex_to_sampled(dims::DimTuple)
     end
 end
 
-function maybe_typemin_as_missingval(filename::String, A::AbstractGeoArray{T}) where T
+function maybe_typemin_as_missingval(filename::String, A::AbstractRaster{T}) where T
     if ismissing(missingval(A))
         newmissingval = typemin(Missings.nonmissingtype(T)) 
         ext = splitext(filename)

--- a/src/write.jl
+++ b/src/write.jl
@@ -1,20 +1,20 @@
 """
-    Base.write(filename::AbstractString, A::AbstractGeoArray; kw...)
+    Base.write(filename::AbstractString, A::AbstractRaster; kw...)
 
-Write an [`AbstractGeoArray`](@ref) to file, guessing the backend from the file extension.
+Write an [`AbstractRaster`](@ref) to file, guessing the backend from the file extension.
 
 Keyword arguments are passed to the `write` method for the backend.
 """
 function Base.write(
-    filename::AbstractString, A::AbstractGeoArray; kw...
+    filename::AbstractString, A::AbstractRaster; kw...
 )
     write(filename, _sourcetype(filename), A; kw...)
 end
 
 """
-    Base.write(filename::AbstractString, s::AbstractGeoStack; suffix, kw...)
+    Base.write(filename::AbstractString, s::AbstractRasterStack; suffix, kw...)
 
-Write any [`AbstractGeoStack`](@ref) to file, guessing the backend from the file extension.
+Write any [`AbstractRasterStack`](@ref) to file, guessing the backend from the file extension.
 
 ## Keywords
 
@@ -24,7 +24,7 @@ Other keyword arguments are passed to the `write` method for the backend.
 
 If the source can't be saved as a stack-like object, individual array layers will be saved.
 """
-function Base.write(filename::AbstractString, s::AbstractGeoStack; suffix=nothing, kw...)
+function Base.write(filename::AbstractString, s::AbstractRasterStack; suffix=nothing, kw...)
     base, ext = splitext(filename)
     T = _sourcetype(filename)
     if haslayers(T)

--- a/test/adapt.jl
+++ b/test/adapt.jl
@@ -1,5 +1,5 @@
-using GeoData, Adapt, Test
-using GeoData.GeoFormatTypes, GeoData.LookupArrays
+using Rasters, Adapt, Test
+using Rasters.GeoFormatTypes, Rasters.LookupArrays
 
 struct CustomArray{T,N} <: AbstractArray{T,N}
     arr::Array

--- a/test/aggregate.jl
+++ b/test/aggregate.jl
@@ -1,6 +1,6 @@
-using GeoData, Test, Dates, Statistics
-using GeoData.LookupArrays, GeoData.Dimensions
-using GeoData: upsample, downsample
+using Rasters, Test, Dates, Statistics
+using Rasters.LookupArrays, Rasters.Dimensions
+using Rasters: upsample, downsample
 
 @testset "upsample" begin
     @test upsample(1, 2) == 1
@@ -28,14 +28,14 @@ data3 = 3 * data1
 data4 = 4 * data1
 dimz = X(Sampled([30., 40., 50.]; order=ForwardOrdered(), span=Regular(10.0), sampling=Points())), 
        Y(Sampled(LinRange(-10., 20., 7); order=ForwardOrdered(), span=Regular(5.0), sampling=Points()))
-array1 = GeoArray(data1, dimz)
-array2 = GeoArray(data2, dimz)
-array1a = GeoArray(data3, dimz)
-array2a = GeoArray(data4, dimz)
-stack1 = GeoStack(array1, array2; keys=(:array1, :array2))
-stack2 = GeoStack(array1a, array2a; keys=(:array1, :array2))
+array1 = Raster(data1, dimz)
+array2 = Raster(data2, dimz)
+array1a = Raster(data3, dimz)
+array2a = Raster(data4, dimz)
+stack1 = RasterStack(array1, array2; keys=(:array1, :array2))
+stack2 = RasterStack(array1a, array2a; keys=(:array1, :array2))
 dates = DateTime(2017):Year(1):DateTime(2018)
-series = GeoSeries([stack1, stack2], (Ti(dates),));
+series = RasterSeries([stack1, stack2], (Ti(dates),));
 
 
 @testset "Aggregate a dimension" begin
@@ -107,7 +107,7 @@ end
             [32 32 32 44 44 44
              32 32 32 44 44 44
              32 32 32 44 44 44]
-        @test typeof(aggregate(Start(), series, scale)) <: GeoSeries
+        @test typeof(aggregate(Start(), series, scale)) <: RasterSeries
     end
 
     @testset "mixed scales" begin
@@ -157,13 +157,13 @@ end
     data_m = [ 1  2  3  4  5  6 -1
                7  8  9 10 11 12 -1
               13 14 15 16 missing 18 -1]
-    array_m = GeoArray(data_m, dimz)
+    array_m = Raster(data_m, dimz)
     @test all(aggregate(sum, array_m, 3) .=== [72 missing])
     @test all(aggregate(sum, array_m, 3; skipmissingval=true) .=== [72 82])
     data_m0 = [ 1  2  3  4  5  6 -1
                 7  8  0 10 11 12 -1
                13 14 15 16 17 18 -1]
-    array_m0 = GeoArray(data_m0, dimz; missingval=0)
+    array_m0 = Raster(data_m0, dimz; missingval=0)
     @test aggregate(sum, array_m0, 3) == [0 99]
     @test aggregate(sum, array_m0, 3; skipmissingval=true) == [63 99]
     @test all(aggregate(mean, array_m0, 3) .=== [0.0 11.0])
@@ -173,8 +173,8 @@ end
     data_m = [ 1  2  3  4  5  6 -1
               7  8  9 10 11 12 -1
              13 14 15 16 missing 18 -1]
-    src = GeoArray(data_m, dimz)
-    dst = GeoArray(zeros(1, 2), map(d -> aggregate(mean, d, 3), dimz); missingval=-9999.0)
+    src = Raster(data_m, dimz)
+    dst = Raster(zeros(1, 2), map(d -> aggregate(mean, d, 3), dimz); missingval=-9999.0)
     @test all(aggregate!(sum, dst, src, 3) .=== [72.0 -9999.0])
 end
 
@@ -182,6 +182,6 @@ end
     dimz = Band(1:3), Dim{:category}([:a, :b, :c]), X([10, 20, 30, 40])
     a1 = [1 2 3; 4 5 6; 7 8 9]
     A = cat(a1, a1 .+ 10, a1 .+ 20, a1 .+ 30, dims=3)
-    da = GeoArray(A, dimz)
+    da = Raster(A, dimz)
     @test vec(aggregate(sum, da, (3, 2, 2))) == [114, 354]
 end

--- a/test/array.jl
+++ b/test/array.jl
@@ -1,5 +1,5 @@
-using GeoData, Test, Dates
-using GeoData.LookupArrays, GeoData.Dimensions
+using Rasters, Test, Dates
+using Rasters.LookupArrays, Rasters.Dimensions
 
 data1 = cumsum(cumsum(ones(10, 11); dims=1); dims=2)
 data2 = 2cumsum(cumsum(ones(10, 11, 1); dims=1); dims=2)
@@ -10,8 +10,8 @@ mval = -9999.0
 meta = NoMetadata()
 nme = :test
 
-ga2 = GeoArray(data2, dims2)
-ga1 = GeoArray(data1; dims=dims1, refdims=refdimz, name=nme, metadata=meta, missingval=mval)
+ga2 = Raster(data2, dims2)
+ga1 = Raster(data1; dims=dims1, refdims=refdimz, name=nme, metadata=meta, missingval=mval)
 
 @test ga1 == data1
 @test ga2 == data2
@@ -28,34 +28,34 @@ end
     y = Y(Projected(1.0:1.0:2.0; crs=ProjString("+proj=")))
 
     A1 = rand(Float32, x, y)
-    @test A1 isa GeoArray{Float32,2}
+    @test A1 isa Raster{Float32,2}
     @test size(A1) == (2, 2)
 
     A2 = zeros(Int, x, y)
-    @test A2 isa GeoArray{Int,2}
+    @test A2 isa Raster{Int,2}
     @test A2 == [0 0; 0 0] 
 
     A3 = ones(x, y)
-    @test A3 isa GeoArray{Float64,2}
+    @test A3 isa Raster{Float64,2}
     @test A3 == [1.0 1.0; 1.0 1.0] 
 
     A4 = fill(99.0, x, y)
-    @test A4 isa GeoArray{Float64,2}
+    @test A4 isa Raster{Float64,2}
     @test A4 == [99.0 99.0; 99.0 99.0] 
 
     A5 = trues(x, y)
-    @test A5 isa GeoArray{Bool,2}
+    @test A5 isa Raster{Bool,2}
     @test A5 == [true true; true true] 
 
     A6 = falses(x, y)
-    @test A6 isa GeoArray{Bool,2}
+    @test A6 isa Raster{Bool,2}
     @test A6 == [false false; false false] 
 end
 
 @testset "show" begin
     sh = sprint(show, MIME("text/plain"), ga1)
     # Test but don't lock this down too much
-    @test occursin("GeoArray", sh)
+    @test occursin("Raster", sh)
     @test occursin("Y", sh)
     @test occursin("X", sh)
 end

--- a/test/plotrecipes.jl
+++ b/test/plotrecipes.jl
@@ -1,12 +1,12 @@
-using GeoData, Test, Dates, Plots
+using Rasters, Test, Dates, Plots
 
-ga2 = GeoArray(ones(91) * (-25:15)', (X(0.0:4.0:360.0), Y(-25.0:1.0:15.0), ); name=:Test)
-ga3 = GeoArray(rand(10, 41, 91), (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0)))
-ga4ti = GeoArray(
+ga2 = Raster(ones(91) * (-25:15)', (X(0.0:4.0:360.0), Y(-25.0:1.0:15.0), ); name=:Test)
+ga3 = Raster(rand(10, 41, 91), (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0)))
+ga4ti = Raster(
     rand(10, 41, 91, 4), 
     (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0), Ti(Date(2001):Year(1):Date(2004)))
 )
-ga4x = GeoArray(
+ga4x = Raster(
     rand(10, 41, 91, 4), 
     (Z(100:100:1000), Y(-20.0:1.0:20.0), X(0.0:4.0:360.0), X())
 )
@@ -26,10 +26,10 @@ heatmap(ga4x[X(At(0.0)), Y(At(0.0))])
 plot(ga4x[Y(1)])
 # 3d plot by Ti dim
 plot(ga4ti[Z(1)])
-# GeoData handles filled contours
+# Rasters handles filled contours
 contourf(ga2)
-# GeoStack plot
-plot(GeoStack(ga2, ga3))
+# RasterStack plot
+plot(RasterStack(ga2, ga3))
 
 # DD fallback
 contour(ga2)

--- a/test/reproject.jl
+++ b/test/reproject.jl
@@ -1,6 +1,6 @@
-using GeoData, Test, ArchGDAL
-using GeoData.LookupArrays, GeoData.Dimensions
-using GeoData: reproject, convertlookup
+using Rasters, Test, ArchGDAL
+using Rasters.LookupArrays, Rasters.Dimensions
+using Rasters: reproject, convertlookup
 
 @testset "reproject" begin
     cea = ProjString("+proj=cea +lon_0=0 +lat_ts=30 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs +ellps=WGS84 +towgs84=0,0,0")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,13 @@
-using GeoData, Test, Aqua, SafeTestsets
+using Rasters, Test, Aqua, SafeTestsets
 
 if VERSION >= v"1.5.0"
-    # Aqua.test_ambiguities([GeoData, Base, Core])
-    # Aqua.test_unbound_args(GeoData)
-    # Aqua.test_stale_deps(GeoData)
-    Aqua.test_undefined_exports(GeoData)
-    Aqua.test_project_extras(GeoData)
-    Aqua.test_deps_compat(GeoData)
-    Aqua.test_project_toml_formatting(GeoData)
+    # Aqua.test_ambiguities([Rasters, Base, Core])
+    # Aqua.test_unbound_args(Rasters)
+    # Aqua.test_stale_deps(Rasters)
+    Aqua.test_undefined_exports(Rasters)
+    Aqua.test_project_extras(Rasters)
+    Aqua.test_deps_compat(Rasters)
+    Aqua.test_project_toml_formatting(Rasters)
 end
 
 @time @safetestset "array" begin include("array.jl") end

--- a/test/series.jl
+++ b/test/series.jl
@@ -1,7 +1,7 @@
-using GeoData, Test, Dates
-using GeoData.LookupArrays, GeoData.Dimensions
+using Rasters, Test, Dates
+using Rasters.LookupArrays, Rasters.Dimensions
 
-# GeoSeries from GeoArray/GeoStack components
+# RasterSeries from Raster/RasterStack components
 
 data1 = [1 2 3 4
          5 6 7 8]
@@ -9,19 +9,19 @@ data2 = 2 * data1
 data3 = 3 * data1
 data4 = 4 * data1
 dimz = X([30, 40]), Y(-10.0:10.0:20.0)
-ga1 = GeoArray(data1, dimz)
-ga2 = GeoArray(data2, dimz)
-ga1a = GeoArray(data3, dimz)
-ga2a = GeoArray(data4, dimz)
-stack1 = GeoStack(ga1, ga2; keys=(:ga1, :ga2))
-stack2 = GeoStack(ga1a, ga2a; keys=(:ga1, :ga2))
+ga1 = Raster(data1, dimz)
+ga2 = Raster(data2, dimz)
+ga1a = Raster(data3, dimz)
+ga2a = Raster(data4, dimz)
+stack1 = RasterStack(ga1, ga2; keys=(:ga1, :ga2))
+stack2 = RasterStack(ga1a, ga2a; keys=(:ga1, :ga2))
 dates =[DateTime(2017), DateTime(2018)]
-ser = GeoSeries([stack1, stack2], (Ti(dates),))
+ser = RasterSeries([stack1, stack2], (Ti(dates),))
 @test issorted(dates)
 
 @testset "getindex returns the currect types" begin
-    @test ser[Ti(1)] isa GeoStack{<:NamedTuple}
-    @test ser[Ti(1)][:ga2] isa GeoArray{Int,2}
+    @test ser[Ti(1)] isa RasterStack{<:NamedTuple}
+    @test ser[Ti(1)][:ga2] isa Raster{Int,2}
     @test ser[Ti(1)][:ga2, 1, 1] isa Int
     @test ser[Ti(1)][:ga2][1, 1] isa Int
 end
@@ -67,26 +67,26 @@ end
 end
 
 @testset "slice, combine" begin
-    ga1 = GeoArray(ones(4, 5, 10), (X(), Y(), Ti(10:10:100))) .* reshape(1:10, (1, 1, 10))
+    ga1 = Raster(ones(4, 5, 10), (X(), Y(), Ti(10:10:100))) .* reshape(1:10, (1, 1, 10))
     ga2 = ga1 .* 2
     ser = slice(ga1, Ti)
     @test size(ser) == (10,)
-    combined = GeoData.combine(ser, Ti())
+    combined = Rasters.combine(ser, Ti())
     @test combined == ga1
     @test dims(combined) === dims(ga1)
     ser = slice(ga1, (X, Ti))
     @test size(ser) == (4, 10)
     ser = slice(ga1, (X, Y, Ti))
-    combined2 = GeoData.combine(ser, (X, Y, Ti))
+    combined2 = Rasters.combine(ser, (X, Y, Ti))
     @test combined == ga1 == permutedims(combined2, (X, Y, Ti))
     @test dims(combined) === dims(ga1) == dims(permutedims(combined2, (X, Y, Ti)))
-    stack = GeoStack((ga1=ga1, ga2=ga2))
+    stack = RasterStack((ga1=ga1, ga2=ga2))
     ser = slice(stack, Ti)
     @test size(ser) == (10,)
-    combined = GeoData.combine(ser, Ti)
+    combined = Rasters.combine(ser, Ti)
     ser = slice(stack, (Y, Ti))
     @test size(ser) == (5, 10,)
-    combined = GeoData.combine(ser, (Y, Ti))
+    combined = Rasters.combine(ser, (Y, Ti))
 end
 
 
@@ -95,15 +95,15 @@ end
     ser2 = slice(ga1, (X, Y))
     sh = sprint(show, MIME("text/plain"), ser2)
     # Test but don't lock this down too much
-    @test occursin("GeoSeries", sh)
-    @test occursin("GeoArray", sh)
+    @test occursin("RasterSeries", sh)
+    @test occursin("Raster", sh)
     @test occursin("X", sh)
     @test occursin("Y", sh)
     # 1d
     ser1 = slice(ga1, X)
     sh = sprint(show, MIME("text/plain"), ser1)
     # Test but don't lock this down too much
-    @test occursin("GeoSeries", sh)
-    @test occursin("GeoArray", sh)
+    @test occursin("RasterSeries", sh)
+    @test occursin("Raster", sh)
     @test occursin("X", sh)
 end

--- a/test/set.jl
+++ b/test/set.jl
@@ -1,9 +1,9 @@
-using GeoData, Test
-using GeoData.LookupArrays, GeoData.Dimensions
+using Rasters, Test
+using Rasters.LookupArrays, Rasters.Dimensions
 
 @testset "set"  begin
     A = [missing 7; 2 missing]
-    ga = GeoArray(A, (Y(-20:40:20), X(50:10:60)); missingval=missing)
+    ga = Raster(A, (Y(-20:40:20), X(50:10:60)); missingval=missing)
 
     # Use the Projected lookup, with crs
     lu = Projected(; crs=EPSG(2024))

--- a/test/sources/rasterdatasources.jl
+++ b/test/sources/rasterdatasources.jl
@@ -1,4 +1,4 @@
-using GeoData, RasterDataSources, Test, Dates, NCDatasets, ArchGDAL
+using Rasters, RasterDataSources, Test, Dates, NCDatasets, ArchGDAL
 
 # Too big to test on CI
 # if !haskey(ENV, "CI")
@@ -13,85 +13,85 @@ using GeoData, RasterDataSources, Test, Dates, NCDatasets, ArchGDAL
 
 @testset "load WorldClim Climate" begin
     # Weather time-series
-    ser = GeoSeries(WorldClim{Climate}, :prec; res="10m", month=Jan:March, mappedcrs=EPSG(4326))
+    ser = RasterSeries(WorldClim{Climate}, :prec; res="10m", month=Jan:March, mappedcrs=EPSG(4326))
     # Select Australia, using regular lat/lon selectors
     A = ser[month=Jan]
-    @test A isa GeoArray
+    @test A isa Raster
     A[Y(Between(-10, -45)), X(Between(110, 160))]
-    st = GeoStack(WorldClim{Climate}, (:prec, :tmax); month=1)
+    st = RasterStack(WorldClim{Climate}, (:prec, :tmax); month=1)
     st[:prec]
-    @test st isa GeoStack
+    @test st isa RasterStack
 end
 
 @testset "load WorldClim BioClim" begin
-    A = GeoArray(WorldClim{BioClim}, :Bio_1; mappedcrs=EPSG(4326))
+    A = Raster(WorldClim{BioClim}, :Bio_1; mappedcrs=EPSG(4326))
     A[Y(Between(-10, -45)), X(Between(110, 160))]
-    @test A isa GeoArray
+    @test A isa Raster
     st = stack(WorldClim{BioClim}, (1, 2))
     st[:bio1]
-    @test st isa GeoStack
-    @test A isa GeoArray
+    @test st isa RasterStack
+    @test A isa Raster
 end
 
 @testset "load CHELSA BioClim" begin
-    A = GeoArray(CHELSA{BioClim}, 1; mappedcrs=EPSG(4326))
-    @test GeoData.name(A) == :bio1
-    st = GeoStack(CHELSA{BioClim}, (:bio1, :BIO2))
+    A = Raster(CHELSA{BioClim}, 1; mappedcrs=EPSG(4326))
+    @test Rasters.name(A) == :bio1
+    st = RasterStack(CHELSA{BioClim}, (:bio1, :BIO2))
     @test keys(st) == (:bio1, :bio2)
-    @test A isa GeoArray
-    @test st isa GeoStack
-    @test st[:bio2] isa GeoArray
+    @test A isa Raster
+    @test st isa RasterStack
+    @test st[:bio2] isa Raster
 end
 
 @testset "load EarthEnv HabitatHeterogeneity" begin
-    A = GeoArray(EarthEnv{HabitatHeterogeneity}, :cv; mappedcrs=EPSG(4326))
+    A = Raster(EarthEnv{HabitatHeterogeneity}, :cv; mappedcrs=EPSG(4326))
     A[Y(Between(-10, -45)), X(Between(110, 160))] 
-    st = GeoStack(EarthEnv{HabitatHeterogeneity}, (:cv, :evenness))
-    @test A isa GeoArray
-    @test st isa GeoStack
-    @test st[:evenness] isa GeoArray
+    st = RasterStack(EarthEnv{HabitatHeterogeneity}, (:cv, :evenness))
+    @test A isa Raster
+    @test st isa RasterStack
+    @test st[:evenness] isa Raster
 end
 
 @testset "load EarthEnv LandCover" begin
-    A = GeoArray(EarthEnv{LandCover}, 2; mappedcrs=EPSG(4326))
-    @test GeoData.name(A) == :evergreen_broadleaf_trees
+    A = Raster(EarthEnv{LandCover}, 2; mappedcrs=EPSG(4326))
+    @test Rasters.name(A) == :evergreen_broadleaf_trees
     A[Y(Between(-10, -45)), X(Between(110, 160))]
-    @test A isa GeoArray
-    st = GeoStack(EarthEnv{LandCover}, (:evergreen_broadleaf_trees, :deciduous_broadleaf_trees); mappedcrs=EPSG(4326))
+    @test A isa Raster
+    st = RasterStack(EarthEnv{LandCover}, (:evergreen_broadleaf_trees, :deciduous_broadleaf_trees); mappedcrs=EPSG(4326))
     keys(st) = (:evergreen_broadleaf_trees, :deciduous_broadleaf_trees)
-    @test st isa GeoStack
+    @test st isa RasterStack
 end
 
 @testset "load ALWB" begin
-    A = GeoArray(ALWB{Deciles,Day}, :rain_day; date=DateTime(2019, 10, 19))
+    A = Raster(ALWB{Deciles,Day}, :rain_day; date=DateTime(2019, 10, 19))
     @test crs(A) == EPSG(4326)
-    A = GeoArray(ALWB{Values,Day}, :ss_pct; date=DateTime(2019, 10, 19))
+    A = Raster(ALWB{Values,Day}, :ss_pct; date=DateTime(2019, 10, 19))
     @test crs(A) == EPSG(4326)
-    st = GeoStack(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=DateTime(2019, 10, 19))
+    st = RasterStack(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=DateTime(2019, 10, 19))
     @test crs(st) == EPSG(4326)
     @test crs(st[:s0_pct]) == EPSG(4326)
     dates = DateTime(2019, 10, 19), DateTime(2021, 11, 20)
-    s = GeoSeries(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=dates)
+    s = RasterSeries(ALWB{Values,Day}, (:s0_pct, :ss_pct); date=dates)
     s[1]
-    @test A isa GeoArray
-    @test st isa GeoStack
-    @test s isa GeoSeries
+    @test A isa Raster
+    @test st isa RasterStack
+    @test s isa RasterSeries
 end
 
 # Obscure .Z format may not work on windows
 if Sys.islinux()
     @testset "load AWAP" begin
-        A = GeoArray(AWAP, :rainfall; date=DateTime(2019, 10, 19))
+        A = Raster(AWAP, :rainfall; date=DateTime(2019, 10, 19))
         @test crs(A) == EPSG(4326)
-        st = GeoStack(AWAP; date=DateTime(2019, 10, 19), resize=crop)
+        st = RasterStack(AWAP; date=DateTime(2019, 10, 19), resize=crop)
         @test crs(st) == EPSG(4326)
         dates = DateTime(2019, 09, 19), DateTime(2019, 11, 19)
-        s = GeoSeries(AWAP; date=dates, resize=crop)
-        # s = GeoSeries(AWAP; date=dates, resize=resample, crs=EPSG(4326)) TODO: all the same
-        # s = GeoSeries(AWAP; date=dates, resize=extend) TODO: this is slow !!!
+        s = RasterSeries(AWAP; date=dates, resize=crop)
+        # s = RasterSeries(AWAP; date=dates, resize=resample, crs=EPSG(4326)) TODO: all the same
+        # s = RasterSeries(AWAP; date=dates, resize=extend) TODO: this is slow !!!
         @test crs(s[1][:solar]) == EPSG(4326)
-        @test A isa GeoArray
-        @test st isa GeoStack
-        @test s isa GeoSeries
+        @test A isa Raster
+        @test st isa RasterStack
+        @test s isa RasterSeries
     end
 end

--- a/test/stack.jl
+++ b/test/stack.jl
@@ -1,5 +1,5 @@
-using GeoData, DimensionalData, Test, Statistics, Dates
-using GeoData.LookupArrays, GeoData.Dimensions
+using Rasters, DimensionalData, Test, Statistics, Dates
+using Rasters.LookupArrays, Rasters.Dimensions
 
 data1 = cumsum(cumsum(ones(10, 11); dims=1); dims=2)
 data2 = 2cumsum(cumsum(ones(10, 11, 1); dims=1); dims=2)
@@ -11,24 +11,24 @@ mval = -9999.0
 meta = NoMetadata()
 
 # Formatting only occurs in shorthand constructors
-ga1 = GeoArray(data1, dims1; refdims=refdimz, name=nme, metadata=meta, missingval=mval)
-ga2 = GeoArray(data2, dims2)
+ga1 = Raster(data1, dims1; refdims=refdimz, name=nme, metadata=meta, missingval=mval)
+ga2 = Raster(data2, dims2)
 
 @testset "stack constructors" begin
-    st1 = GeoStack((ga1, ga2); name=(:ga1, :ga2))
-    st2 = GeoStack((ga1, ga2); keys=(:ga1, :ga2))
-    st3 = GeoStack((data1, data2), dims2; keys=(:ga1, :ga2))
-    st4 = GeoStack(st3)
-    st5 = GeoStack(st3, dims2)
+    st1 = RasterStack((ga1, ga2); name=(:ga1, :ga2))
+    st2 = RasterStack((ga1, ga2); keys=(:ga1, :ga2))
+    st3 = RasterStack((data1, data2), dims2; keys=(:ga1, :ga2))
+    st4 = RasterStack(st3)
+    st5 = RasterStack(st3, dims2)
     @test st1 == st2 == st3 == st4 == st5
 
     # The dimension differences are lost because the table
     # is tidy - every column is the same length
-    table_st = GeoStack(DimTable(st3), dims2)
+    table_st = RasterStack(DimTable(st3), dims2)
     @test dims(table_st[:ga1]) isa Tuple{<:X,<:Y,<:Ti}
 end
 
-st = GeoStack((ga1, ga2); name=(:ga1, :ga2))
+st = RasterStack((ga1, ga2); name=(:ga1, :ga2))
 
 @testset "stack layers" begin
     @test length(st) == 2
@@ -44,7 +44,7 @@ st = GeoStack((ga1, ga2); name=(:ga1, :ga2))
     @test names(st) == (:ga1, :ga2)
     @test collect(values(st)) == [ga1, ga2]
     # We can iterate/splat stacks as GeArrays
-    @test st == GeoStack(st...)
+    @test st == RasterStack(st...)
 end
 
 @testset "st fields " begin
@@ -61,20 +61,20 @@ end
     @inferred st[:ga1][X=2:4, Y=5:6]
     # FIXME: This isn't inferred, the constants don't propagate like they
     # do in the above call. Probably due to the anonymous wrapper function.
-    @test_broken @inferred st[:ga1, X(2:4), Y(5:6)] isa GeoArray
+    @test_broken @inferred st[:ga1, X(2:4), Y(5:6)] isa Raster
 
-    # Getindex for a whole st of new GeoArrays
+    # Getindex for a whole st of new Rasters
     a = st[X=2:4, Y=5:6]
-    @test a isa GeoStack
-    @test a[:ga1] isa GeoArray
+    @test a isa RasterStack
+    @test a[:ga1] isa Raster
     @test parent(a[:ga1]) isa Array
     @test a[:ga1] == data1[2:4, 5:6]
     @test a[:ga2] == data2[2:4, 5:6, 1:1]
 
     @testset "select new arrays for the whole st" begin
         s = st[Y=Between(-10, 10.0), Ti=At(DateTime(2019))]
-        @test s isa GeoStack
-        @test s[:ga1] isa GeoArray
+        @test s isa RasterStack
+        @test s[:ga1] isa Raster
         @test parent(s[:ga1]) isa Array
         @test s[:ga1] == data1[:, 5:7]
         @test s[:ga2] == data2[:, 5:7, 1]
@@ -86,19 +86,19 @@ end
 
     @testset "select views of arrays for the whole st" begin
         sv = view(st, Y=Between(-4.0, 27.0), Ti=At(DateTime(2019)))
-        @test sv isa GeoStack
-        @test sv[:ga1] isa GeoArray
+        @test sv isa RasterStack
+        @test sv[:ga1] isa Raster
         @test parent(sv[:ga1]) isa SubArray
         @test sv[:ga1] == data1[:, 6:8]
         @test sv[:ga2] == data2[:, 6:8, 1]
         @test dims(sv[:ga2]) == (X(Sampled(10.0:10:100.0, ForwardOrdered(), Regular(10.0), Points(), NoMetadata())),
                                  Y(Sampled(0.0:10:20.0, ForwardOrdered(), Regular(10.0), Points(), NoMetadata())))
         @test refdims(sv[:ga2])[1] == Ti(Sampled(view([DateTime(2019)], 1:1), ForwardOrdered(), Irregular((nothing, nothing)), Points(), NoMetadata()))
-        # Stack of view-based GeoArrays
+        # Stack of view-based Rasters
         v = view(st, X(2:4), Y(5:6))
         # @inferred view(st, X(2:4), Y(5:6))
-        @test v isa GeoStack
-        @test v[:ga1] isa GeoArray
+        @test v isa RasterStack
+        @test v[:ga1] isa Raster
         @test parent(v[:ga1]) isa SubArray
         @test v[:ga1] == view(data1, 2:4, 5:6)
         @test v[:ga2] == view(data2, 2:4, 5:6, 1:1)
@@ -107,10 +107,10 @@ end
 end
 
 @testset "subset st with specific key(s)" begin
-    s1 = GeoStack(st; keys=(:ga2,))
+    s1 = RasterStack(st; keys=(:ga2,))
     @test keys(s1) == (:ga2,)
     @test length(values(s1)) == 1
-    s2 = GeoStack(st; keys=(:ga1, :ga2))
+    s2 = RasterStack(st; keys=(:ga1, :ga2))
     @test keys(s2) == (:ga1, :ga2)
     @test length(values(s2)) == 2
 end
@@ -118,8 +118,8 @@ end
 @testset "concatenate stacks" begin
     dims1b = X(110:10:200), Y(-50:10:50)
     dims2b = (dims1b..., Ti([DateTime(2019)]))
-    stack_a = GeoStack((ga1=ga1, ga2=ga2))
-    stack_b = GeoStack((ga1=GeoArray(data1 .+ 10, dims1b), ga2=GeoArray(data2 .+ 20, dims2b)))
+    stack_a = RasterStack((ga1=ga1, ga2=ga2))
+    stack_b = RasterStack((ga1=Raster(data1 .+ 10, dims1b), ga2=Raster(data2 .+ 20, dims2b)))
     catstack = cat(stack_a, stack_b; dims=X())
     @test size(first(catstack)) == (20, 11)
     @test val(dims(catstack, X)) ≈ 10.0:10.0:200.0
@@ -140,7 +140,7 @@ end
 @testset "show" begin
     sh = sprint(show, st)
     # Test but don't lock this down too much
-    @test occursin("GeoStack", sh)
+    @test occursin("RasterStack", sh)
     @test occursin("Y", sh)
     @test occursin("X", sh)
 end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,6 +1,6 @@
 # Loader for external sources
 maybedownload(url, filename=splitdir(url)[2]) = begin
-    dirpath = joinpath(dirname(pathof(GeoData)), "../test/data")
+    dirpath = joinpath(dirname(pathof(Rasters)), "../test/data")
     mkpath(dirpath)
     filepath = joinpath(dirpath, filename) 
     isfile(filepath) || download(url, filepath)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,5 @@
-using GeoData, Test
-using GeoData: cleankeys
+using Rasters, Test
+using Rasters: cleankeys
 
 @testset "cleankeys" begin
     @test cleankeys(["a", "b", "c"]) == (:a, :b, :c)


### PR DESCRIPTION
This PR renames GeoData.jl to Rasters.jl.

If/when merged this repo will be renamed and the old GeoData.jl will be archived under this name shortly afterwards.

Code changes in this PR:

`GeoArray` -> `Raster`
`GeoStack` -> `RasterStack`
`GeoSeries` -> `RasterSeries`
